### PR TITLE
Feat/shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "DocKit",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "DocKit",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "DocKit",
   "productName": "DocKit",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A faster, better and more stable NoSQL desktop tools",
   "author": "geekfun <support@geekfun.club>",
   "license": "Apache-2.0",

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -105,7 +105,7 @@ export const useConnectionStore = defineStore('connectionStore', {
       const data = (await client.get('/_cat/indices', 'format=json')) as Array<{
         [key: string]: string;
       }>;
-      this.established!.indices = data.map((index: { [key: string]: string }) => ({
+      this.established.indices = data.map((index: { [key: string]: string }) => ({
         ...index,
         docs: {
           count: parseInt(index['docs.count'], 10),

--- a/src/views/editor/index.vue
+++ b/src/views/editor/index.vue
@@ -76,6 +76,15 @@ monaco.languages.setMonarchTokensProvider(
   'search',
   searchTokensProvider as monaco.languages.IMonarchLanguage,
 );
+monaco.languages.setLanguageConfiguration('search', {
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+  ],
+});
 
 // https://github.com/tjx666/adobe-devtools/commit/8055d8415ed3ec5996880b3a4ee2db2413a71c61
 let displayEditor: Editor | null = null;


### PR DESCRIPTION
add more shortcuts

refer: #36 


| Feature         | Shortcut                | Description                                                  | State              |
| --------------- | ----------------------- | ------------------------------------------------------------ | ------------------ |
| General editing | `Ctrl/Cmd + I`          | Auto indent current request.                                 | :white_check_mark: |
| General editing | `Ctrl + Space`          | Open Autocomplete (even if not typing).                      | :white_check_mark: |
| General editing | `Ctrl/Cmd + Enter`      | Submit request.                                              | :white_check_mark: |
| General editing | `Ctrl/Cmd + Up/Down`    | Jump to the previous/next request start or end.              | :white_check_mark: |
| General editing | `Ctrl/Cmd + Alt + L`    | Collapse/expand current scope.                               | :white_check_mark: |
| General editing | `Ctrl/Cmd + Option + 0` | Collapse all scopes but the current one. Expand by adding a shift. | :white_check_mark: |
| Autocomplete    | `Down arrow`            | Switch focus to autocomplete menu. Use arrows to further select a term. | :white_check_mark: |
| Autocomplete    | `Enter/Tab`             | Select the currently selected or the top most term in autocomplete menu. | :white_check_mark: |
| Autocomplete    | `Esc`                   | Close autocomplete menu.                                     | :white_check_mark: |

