### PR TITLE
feat: re-set the position after format

### DIFF
--- a/src/views/editor/index.vue
+++ b/src/views/editor/index.vue
@@ -204,6 +204,7 @@ const autoIndentAction = (editor: monaco.editor.IStandaloneCodeEditor, position:
       // @ts-ignore
       inverseEditOperations => [],
     );
+    editor.setPosition({ lineNumber: startLineNumber + 1, column: 1 });
   } catch (err) {
     message.error(lang.t('editor.invalidJson'), {
       closable: true,


### PR DESCRIPTION
feat: set the position to the start of action line after user trigger indent action
obsolete now.

Refs: #150 
