### PR TITLE
feat: restore display before show the new response

### DIFF
--- a/src/views/editor/index.vue
+++ b/src/views/editor/index.vue
@@ -204,6 +204,7 @@ const autoIndentAction = (editor: monaco.editor.IStandaloneCodeEditor, position:
       // @ts-ignore
       inverseEditOperations => [],
     );
+    editor.setPosition({ lineNumber: startLineNumber + 1, column: 1 });
   } catch (err) {
     message.error(lang.t('editor.invalidJson'), {
       closable: true,

--- a/src/views/editor/index.vue
+++ b/src/views/editor/index.vue
@@ -152,6 +152,7 @@ const executeQueryAction = async (position: { column: number; lineNumber: number
   }
 
   try {
+    displayJsonEditor('');
     if (!established.value) {
       message.error(lang.t('editor.establishedRequired'), {
         closable: true,


### PR DESCRIPTION
feat: restore display before show the new response

when trigger a new action, restore the display editor before sending the request, 
then displays the response, improves the action reactions that user can notice the displays content has updated

Refs: #150 
