### PR TITLE
fix: non-index related action not work

### DIFF
--- a/src/common/monaco/completion.ts
+++ b/src/common/monaco/completion.ts
@@ -23,7 +23,7 @@ const providePathCompletionItems = (lineContent: string) => {
       ],
     };
   }
-  const isPathMatch = /^(GET|POST|PUT|DELETE)(\s+[a-zA-Z0-9_\/-?\-&,]*)$/.test(lineContent);
+  const isPathMatch = /^(GET|POST|PUT|DELETE)(\s+[a-zA-Z0-9_\/-?\-&,*]*)$/.test(lineContent);
   const word = lineContent.split(/[ /]+/).pop() || '';
   if (isPathMatch) {
     return {

--- a/src/common/monaco/lexerRules.ts
+++ b/src/common/monaco/lexerRules.ts
@@ -1,7 +1,7 @@
 import { keywords } from './keywords.ts';
 
 export const executeActions = {
-  regexp: /^(GET|DELETE|POST|PUT)\s+[a-zA-Z0-9_\/-?\-&,.]*/,
+  regexp: /^(GET|DELETE|POST|PUT)\s+[a-zA-Z0-9_\/-?\-&,.*]*/,
   decorationClassName: 'action-execute-decoration',
 };
 
@@ -28,7 +28,7 @@ export const search = {
     // The main tokenizer for our languages
     tokenizer: {
       root: [
-        [/^(GET|POST|PUT|DELETE)(\s+[a-zA-Z0-9_\/-?\-&,.]*)/, ['type', 'regexp']],
+        [/^(GET|POST|PUT|DELETE)(\s+[a-zA-Z0-9_\/-?\-&,.*]*)/, ['type', 'regexp']],
         {
           regex: '{',
           action: {

--- a/src/components/tool-bar.vue
+++ b/src/components/tool-bar.vue
@@ -11,7 +11,11 @@
       @update:show="isOpen => handleOpen(isOpen, 'CONNECTION')"
       @update:value="value => handleUpdate(value, 'CONNECTION')"
       @search="input => handleSearch(input, 'CONNECTION')"
-    />
+    >
+      <template v-if="selectionState.connection" #arrow>
+        <Search />
+      </template>
+    </n-select>
     <n-select
       v-if="props.type === 'EDITOR'"
       :options="options.index"
@@ -19,11 +23,16 @@
       :input-props="inputProps"
       remote
       filterable
+      clearable
       :loading="loadingRef.index"
       @update:value="value => handleUpdate(value, 'INDEX')"
       @update:show="isOpen => handleOpen(isOpen, 'INDEX')"
       @search="input => handleSearch(input, 'INDEX')"
-    />
+    >
+      <template v-if="selectionState.index" #arrow>
+        <Search />
+      </template>
+    </n-select>
     <n-tooltip v-if="props.type === 'EDITOR'" trigger="hover">
       <template #trigger>
         <n-icon size="20" class="action-load-icon" @click="loadDefaultSnippet">
@@ -49,7 +58,7 @@
 </template>
 
 <script setup lang="ts">
-import { AiStatus } from '@vicons/carbon';
+import { AiStatus, Search } from '@vicons/carbon';
 import { storeToRefs } from 'pinia';
 import { useConnectionStore, useTabStore } from '../store';
 import { useLang } from '../lang';
@@ -73,7 +82,10 @@ const { loadDefaultSnippet } = tabStore;
 const loadingRef = ref({ connection: false, index: false });
 
 const filterRef = ref({ connection: '', index: '' });
-
+const selectionState = ref<{ connection: boolean; index: boolean }>({
+  connection: false,
+  index: false,
+});
 const options = computed(
   () =>
     ({
@@ -89,7 +101,13 @@ const options = computed(
 );
 
 const handleOpen = async (isOpen: boolean, type: 'CONNECTION' | 'INDEX') => {
-  if (!isOpen) return;
+  if (!isOpen) {
+    // @ts-ignore
+    selectionState.value[type.toLowerCase()] = false;
+    return;
+  }
+  // @ts-ignore
+  selectionState.value[type.toLowerCase()] = true;
   filterRef.value = { connection: '', index: '' }; // reset filters for each time it open
   if (type === 'CONNECTION') {
     loadingRef.value.connection = true;

--- a/src/views/editor/index.vue
+++ b/src/views/editor/index.vue
@@ -246,6 +246,7 @@ const setupQueryEditor = () => {
   if (!queryEditor) {
     return;
   }
+  queryEditor.getModel()?.updateOptions({ tabSize: 2 });
 
   queryEditor.onDidChangeModelContent(_changes => {
     saveModelContent(false, false, false);


### PR DESCRIPTION
fix: non-index related action not work

This pull request includes several changes to improve the functionality and user experience of the `tool-bar` component and enhance the `lexerRules` and `connectionStore` files. The most significant updates involve the addition of a `Search` icon, modifications to the `selectionState`, and improvements to the path-building logic.

Enhancements to `tool-bar` component:

* Added a `Search` icon to the `n-select` components when a selection is made. (`src/components/tool-bar.vue`) [[1]](diffhunk://#diff-41529f6c831b85b601d7be26f3a5b99e5e80914851b3e9f3bcac05527d28cc52L14-R35) [[2]](diffhunk://#diff-41529f6c831b85b601d7be26f3a5b99e5e80914851b3e9f3bcac05527d28cc52L52-R61)
* Introduced `selectionState` to manage the state of selections in the `n-select` components. (`src/components/tool-bar.vue`)
* Updated the `handleOpen` method to reset the `selectionState` when the dropdown is closed. (`src/components/tool-bar.vue`)

Improvements to `lexerRules`:

* Updated the regular expressions for `executeActions` and `search` to allow asterisks (`*`) in the paths. (`src/common/monaco/lexerRules.ts`) [[1]](diffhunk://#diff-9660ab813f56d6715b62febf3350990bad99810ec164555513d4754d4a63de61L4-R4) [[2]](diffhunk://#diff-9660ab813f56d6715b62febf3350990bad99810ec164555513d4754d4a63de61L31-R31)

Enhancements to `connectionStore`:

* Added a list of `globalPathActions` to centralize the handling of global path actions in the `buildPath` function. (`src/store/connectionStore.ts`)
* Improved the `buildPath` function to better handle user-specified paths and global path actions. (`src/store/connectionStore.ts`)

Refs: #178 
