### PR TITLE
Fix: windows shortcut issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# DocKit - AI Agent Guidelines
+
+## Project Overview
+
+DocKit is a Tauri v2 + Vue 3 + TypeScript desktop client for NoSQL databases (Elasticsearch, OpenSearch, DynamoDB).
+
+**Tech Stack**: Tauri v2 (Rust backend), Vue 3 (Composition API), TypeScript, Monaco Editor, shadcn-vue + UnoCSS (styling).
+
+**Key Directories**:
+
+- `src/` - Vue frontend application
+- `src-tauri/` - Rust backend (Tauri)
+- `src/composables/` - Vue composables (reusable logic)
+- `src/views/` - Page-level components
+- `src/components/` - Shared UI components
+- `src/components/ui/` - shadcn-vue components
+
+---
+
+## Coding/Architecture Guidelines
+
+### Functional TypeScript
+
+- Define functions as `const xxx = (...) => ...`. Prefer **functional decomposition** over OOP.
+- **Avoid classes** unless strictly necessary.
+
+### Declarative/Functional Collection Handling
+
+- Replace `for`/`while` loops with `map`, `filter`, `find`, `some`, `every`, `reduce`, `flatMap` (and `sort` when appropriate).
+- Favor pipeline-style transformations over step-by-step imperative logic.
+
+### Immutability
+
+- Avoid in-place mutation (`push`, `splice`, mutating objects/arrays, shared mutable state).
+- Instead, return new arrays/objects and model changes as explicit state-transform functions (e.g., reducers).
+
+### Pure Functions
+
+- Keep functions small, composable, and side-effect-free where possible.
+- If effects are required (I/O, logging), isolate them at the boundaries and keep core logic pure.
+
+### Types
+
+- Prefer `type`/`enum` over `interface` where possible.
+- Use `type` when it can fully replace an `interface`.
+
+### Module Boundaries
+
+- Each module should export **only** via its `index.ts`.
+- Avoid deep imports (e.g., import from `src/composables/useKeyboardShortcuts` → use `src/composables`).
+
+### Export Discipline
+
+- Only export functions/types/constants that are used outside the module.
+
+### Provider-Agnostic Design
+
+- Keep provider-agnostic abstractions and follow clean separation of concerns.
+
+### Comments and Documentation
+
+- Use as few inline comments as possible.
+- Behavior should be clear from tests and naming.
+
+---
+
+## Styling Conventions
+
+- **UnoCSS** for utility-first atomic CSS (loaded via `virtual:uno.css`)
+- **shadcn-vue** for UI components (Radix Vue-based, headless)
+- Theme tokens via CSS variables in `src/assets/styles/index.css`
+- See `uno.config.ts` for UnoCSS presets and theme configuration
+
+---
+
+## Code Quality Tools
+
+- **ESLint**: `npm run lint:check` (check violations), `npm run lint:fix` (auto-fix)
+- **TypeScript**: Strict mode enabled (`noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`)
+- **Prettier**: Single quotes, 100 char width, 2-space indent, semicolons, arrow parens `avoid`
+
+---
+
+## Build Commands
+
+```bash
+npm install        # Install dependencies
+npm run tauri dev  # Compile and run (development)
+npm run lint:check # Check ESLint violations
+npm run lint:fix   # Auto-fix ESLint issues
+npx tsc --noEmit   # TypeScript type check
+```

--- a/src/components/shortcuts-help-dialog.vue
+++ b/src/components/shortcuts-help-dialog.vue
@@ -17,9 +17,7 @@
                 <td class="shortcut-keys">
                   <kbd>{{ cmdKey }}</kbd>
                   <span class="key-separator">+</span>
-                  <kbd>Shift</kbd>
-                  <span class="key-separator">+</span>
-                  <kbd>/</kbd>
+                  <kbd>?</kbd>
                 </td>
               </tr>
               <tr>
@@ -78,7 +76,7 @@
                   <span class="key-separator">,</span>
                   <kbd>{{ cmdKey }}</kbd>
                   <span class="key-separator">+</span>
-                  <kbd>-</kbd>
+                  <kbd>0</kbd>
                 </td>
               </tr>
               <tr>

--- a/src/components/tool-bar.vue
+++ b/src/components/tool-bar.vue
@@ -305,6 +305,13 @@ const hideSystemIndicesRef = ref(true);
 const isExecuting = ref(false);
 const showShortcutsDialog = ref(false);
 
+// Called by parent when editor emits toggle-shortcuts-dialog
+const toggleShortcutsDialog = () => {
+  showShortcutsDialog.value = !showShortcutsDialog.value;
+};
+
+defineExpose({ toggleShortcutsDialog });
+
 // Platform-aware key display for shortcuts hint
 const cmdKey = computed(() => {
   try {
@@ -312,30 +319,6 @@ const cmdKey = computed(() => {
   } catch {
     return 'Ctrl';
   }
-});
-
-// Keyboard shortcut to toggle shortcuts dialog (Ctrl+Shift+/ or Cmd+Shift+/)
-// Note: Shift+/ produces '?' as event.key, so we check for both
-const handleKeyboardShortcut = (event: KeyboardEvent) => {
-  // Ctrl+Shift+/ on Windows/Linux, Cmd+Shift+/ on macOS
-  if (
-    (event.ctrlKey || event.metaKey) &&
-    event.shiftKey &&
-    (event.key === '/' || event.key === '?')
-  ) {
-    event.preventDefault();
-    showShortcutsDialog.value = !showShortcutsDialog.value;
-  }
-};
-
-onMounted(() => {
-  if (props.type === 'ES_EDITOR' || props.type === 'DYNAMO_EDITOR') {
-    document.addEventListener('keydown', handleKeyboardShortcut);
-  }
-});
-
-onUnmounted(() => {
-  document.removeEventListener('keydown', handleKeyboardShortcut);
 });
 
 const connectionSelectValue = computed(() => {

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -11,3 +11,4 @@ export { useLoadingBarService } from './useLoadingBarService';
 export { useFormValidation } from './useFormValidation';
 export { useAppUpdater } from './useAppUpdater';
 export { setupEditorKeyboardShortcuts } from './useKeyboardShortcuts';
+export { setupGlobalShortcuts } from './useGlobalShortcuts';

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -10,3 +10,4 @@ export { useMessageService } from './useMessageService';
 export { useLoadingBarService } from './useLoadingBarService';
 export { useFormValidation } from './useFormValidation';
 export { useAppUpdater } from './useAppUpdater';
+export { setupEditorKeyboardShortcuts } from './useKeyboardShortcuts';

--- a/src/composables/useGlobalShortcuts.ts
+++ b/src/composables/useGlobalShortcuts.ts
@@ -1,0 +1,61 @@
+/**
+ * Global keyboard shortcut handler for app-wide shortcuts.
+ *
+ * Some shortcuts like "show all shortcuts dialog" should work when the editor tab
+ * is open, regardless of whether the Monaco editor DOM has focus. This module
+ * attaches document-level listeners to handle these app-wide shortcuts.
+ *
+ * Uses capture phase (third argument `true`) to intercept events before
+ * browser shortcuts (like Ctrl+J for Downloads on Windows) can fire.
+ */
+
+interface GlobalShortcutSpec {
+  key: string | string[];
+  ctrlOrMeta: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  handler: () => void;
+}
+
+interface GlobalShortcutOptions {
+  shortcuts: GlobalShortcutSpec[];
+  isActive: () => boolean; // Returns true if the editor tab/view is currently active
+}
+
+function hasCtrlOrMeta(e: KeyboardEvent): boolean {
+  return e.ctrlKey || e.metaKey;
+}
+
+function matchesGlobalStroke(e: KeyboardEvent, spec: GlobalShortcutSpec): boolean {
+  if (spec.ctrlOrMeta && !hasCtrlOrMeta(e)) return false;
+  if (!spec.ctrlOrMeta && hasCtrlOrMeta(e)) return false;
+  if (spec.shift !== undefined && spec.shift !== e.shiftKey) return false;
+  if (spec.alt !== undefined && spec.alt !== e.altKey) return false;
+  const keys = Array.isArray(spec.key) ? spec.key : [spec.key];
+  return keys.some(k => e.key.toLowerCase() === k.toLowerCase());
+}
+
+export function setupGlobalShortcuts(options: GlobalShortcutOptions): () => void {
+  const { shortcuts, isActive } = options;
+
+  function handleKeyDown(e: KeyboardEvent) {
+    // Only handle shortcuts when the editor tab/view is active
+    if (!isActive()) return;
+
+    for (const shortcut of shortcuts) {
+      if (matchesGlobalStroke(e, shortcut)) {
+        e.preventDefault();
+        e.stopPropagation();
+        shortcut.handler();
+        return;
+      }
+    }
+  }
+
+  // Use capture phase to intercept before browser shortcuts
+  document.addEventListener('keydown', handleKeyDown, true);
+
+  return () => {
+    document.removeEventListener('keydown', handleKeyDown, true);
+  };
+}

--- a/src/composables/useGlobalShortcuts.ts
+++ b/src/composables/useGlobalShortcuts.ts
@@ -1,61 +1,42 @@
-/**
- * Global keyboard shortcut handler for app-wide shortcuts.
- *
- * Some shortcuts like "show all shortcuts dialog" should work when the editor tab
- * is open, regardless of whether the Monaco editor DOM has focus. This module
- * attaches document-level listeners to handle these app-wide shortcuts.
- *
- * Uses capture phase (third argument `true`) to intercept events before
- * browser shortcuts (like Ctrl+J for Downloads on Windows) can fire.
- */
-
-interface GlobalShortcutSpec {
+type GlobalShortcutSpec = {
   key: string | string[];
   ctrlOrMeta: boolean;
   shift?: boolean;
   alt?: boolean;
   handler: () => void;
-}
+};
 
-interface GlobalShortcutOptions {
+type GlobalShortcutOptions = {
   shortcuts: GlobalShortcutSpec[];
-  isActive: () => boolean; // Returns true if the editor tab/view is currently active
-}
+  isActive: () => boolean;
+};
 
-function hasCtrlOrMeta(e: KeyboardEvent): boolean {
-  return e.ctrlKey || e.metaKey;
-}
+const hasCtrlOrMeta = (e: KeyboardEvent): boolean => e.ctrlKey || e.metaKey;
 
-function matchesGlobalStroke(e: KeyboardEvent, spec: GlobalShortcutSpec): boolean {
-  if (spec.ctrlOrMeta && !hasCtrlOrMeta(e)) return false;
-  if (!spec.ctrlOrMeta && hasCtrlOrMeta(e)) return false;
+const matchesGlobalStroke = (e: KeyboardEvent, spec: GlobalShortcutSpec): boolean => {
+  if (spec.ctrlOrMeta !== hasCtrlOrMeta(e)) return false;
   if (spec.shift !== undefined && spec.shift !== e.shiftKey) return false;
   if (spec.alt !== undefined && spec.alt !== e.altKey) return false;
   const keys = Array.isArray(spec.key) ? spec.key : [spec.key];
   return keys.some(k => e.key.toLowerCase() === k.toLowerCase());
-}
+};
 
-export function setupGlobalShortcuts(options: GlobalShortcutOptions): () => void {
+export const setupGlobalShortcuts = (options: GlobalShortcutOptions): (() => void) => {
   const { shortcuts, isActive } = options;
 
-  function handleKeyDown(e: KeyboardEvent) {
-    // Only handle shortcuts when the editor tab/view is active
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (!isActive()) return;
-
-    for (const shortcut of shortcuts) {
-      if (matchesGlobalStroke(e, shortcut)) {
-        e.preventDefault();
-        e.stopPropagation();
-        shortcut.handler();
-        return;
-      }
+    const matched = shortcuts.find(s => matchesGlobalStroke(e, s));
+    if (matched) {
+      e.preventDefault();
+      e.stopPropagation();
+      matched.handler();
     }
-  }
+  };
 
-  // Use capture phase to intercept before browser shortcuts
   document.addEventListener('keydown', handleKeyDown, true);
 
   return () => {
     document.removeEventListener('keydown', handleKeyDown, true);
   };
-}
+};

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -6,9 +6,15 @@
  * non-US layouts (French AZERTY, German QWERTZ, etc.) where `/` and `-` are at
  * different physical key positions.
  *
- * This module intercepts `keydown` events on the editor DOM and checks `event.key`
- * (logical character) instead of `event.keyCode` (physical position), which works
+ * This module intercepts `keydown` events and checks `event.key` (logical
+ * character) instead of `event.keyCode` (physical position), which works
  * correctly regardless of keyboard layout.
+ *
+ * Single-stroke shortcuts are attached to the editor DOM node (capture phase).
+ * Chord shortcuts are attached to `document` (capture phase) because on
+ * macOS/WKWebView the second stroke's keydown event may be retargeted after the
+ * first stroke's stopPropagation, causing it to miss the editor DOM node
+ * listener. Document-level capture ensures the second stroke is always caught.
  */
 
 import type { Editor } from '../common/monaco';
@@ -57,7 +63,7 @@ export function setupEditorKeyboardShortcuts(
   const { shortcuts = [], chords = [] } = options;
 
   let chordState: {
-    chord: ChordBinding;
+    candidates: ChordBinding[];
     timeoutId: ReturnType<typeof setTimeout>;
   } | null = null;
 
@@ -68,35 +74,39 @@ export function setupEditorKeyboardShortcuts(
     }
   }
 
-  function handleKeyDown(e: KeyboardEvent) {
+  // Chord handler on document — first stroke requires editor focus,
+  // second stroke fires regardless of target (handles WKWebView retargeting).
+  function handleChordKeyDown(e: KeyboardEvent) {
     if (chordState) {
-      const { chord } = chordState;
-      if (matchesStroke(e, chord.second)) {
-        e.preventDefault();
-        e.stopPropagation();
-        clearChordState();
-        chord.handler();
-        return;
+      for (const candidate of chordState.candidates) {
+        if (matchesStroke(e, candidate.second)) {
+          e.preventDefault();
+          e.stopPropagation();
+          clearChordState();
+          candidate.handler();
+          return;
+        }
       }
       clearChordState();
+      return;
     }
 
-    for (const chord of chords) {
-      if (matchesStroke(e, chord.first)) {
-        // Chord prefixes take precedence over single-stroke shortcuts.
-        // Example: when Ctrl/Cmd+K starts a chord, we consume it immediately
-        // so Monaco never sees that first stroke. If we later introduce a
-        // standalone Ctrl/Cmd+K binding, this ordering must be revisited.
-        e.preventDefault();
-        e.stopPropagation();
-        clearChordState();
-        chordState = {
-          chord,
-          timeoutId: setTimeout(clearChordState, CHORD_TIMEOUT_MS),
-        };
-        return;
-      }
+    if (!editor.hasTextFocus()) return;
+
+    const candidates = chords.filter(chord => matchesStroke(e, chord.first));
+    if (candidates.length > 0) {
+      e.preventDefault();
+      e.stopPropagation();
+      chordState = {
+        candidates,
+        timeoutId: setTimeout(clearChordState, CHORD_TIMEOUT_MS),
+      };
     }
+  }
+
+  // Single-stroke handler on editor DOM node — unaffected by the chord bug.
+  function handleSingleKeyDown(e: KeyboardEvent) {
+    if (chordState) return;
 
     for (const shortcut of shortcuts) {
       if (matchesStroke(e, shortcut)) {
@@ -108,15 +118,20 @@ export function setupEditorKeyboardShortcuts(
     }
   }
 
+  if (chords.length > 0) {
+    document.addEventListener('keydown', handleChordKeyDown, true);
+  }
+
   const domNode = editor.getDomNode();
-  if (domNode) {
-    domNode.addEventListener('keydown', handleKeyDown, true);
+  if (domNode && shortcuts.length > 0) {
+    domNode.addEventListener('keydown', handleSingleKeyDown, true);
   }
 
   return () => {
     clearChordState();
+    document.removeEventListener('keydown', handleChordKeyDown, true);
     if (domNode) {
-      domNode.removeEventListener('keydown', handleKeyDown, true);
+      domNode.removeEventListener('keydown', handleSingleKeyDown, true);
     }
   };
 }

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -1,76 +1,56 @@
-/**
- * DOM-level keyboard shortcut handler for Monaco Editor.
- *
- * Monaco standalone uses `USLayoutResolvedKeybinding` which maps KeyCode values
- * to physical US key positions. This breaks shortcuts like Ctrl+/ and Ctrl+- on
- * non-US layouts (French AZERTY, German QWERTZ, etc.) where `/` and `-` are at
- * different physical key positions.
- *
- * This module intercepts `keydown` events and checks `event.key` (logical
- * character) instead of `event.keyCode` (physical position), which works
- * correctly regardless of keyboard layout.
- *
- * Single-stroke shortcuts are attached to the editor DOM node (capture phase).
- * Chord shortcuts are attached to `document` (capture phase) because on
- * macOS/WKWebView the second stroke's keydown event may be retargeted after the
- * first stroke's stopPropagation, causing it to miss the editor DOM node
- * listener. Document-level capture ensures the second stroke is always caught.
- */
-
 import type { Editor } from '../common/monaco';
 
-interface StrokeSpec {
+type StrokeSpec = {
   key: string | string[];
   ctrlOrMeta: boolean;
   shift?: boolean;
   alt?: boolean;
-}
+};
 
-interface ShortcutBinding extends StrokeSpec {
+type ShortcutBinding = StrokeSpec & {
   handler: () => void;
-}
+};
 
-interface ChordBinding {
+type ChordBinding = {
   first: StrokeSpec;
   second: StrokeSpec;
   handler: () => void;
-}
+};
 
-interface EditorShortcutOptions {
+type EditorShortcutOptions = {
   shortcuts?: ShortcutBinding[];
   chords?: ChordBinding[];
-}
+};
 
-function hasCtrlOrMeta(e: KeyboardEvent): boolean {
-  return e.ctrlKey || e.metaKey;
-}
-
-function matchesStroke(e: KeyboardEvent, stroke: StrokeSpec): boolean {
-  if (stroke.ctrlOrMeta && !hasCtrlOrMeta(e)) return false;
-  if (!stroke.ctrlOrMeta && hasCtrlOrMeta(e)) return false;
-  if ((stroke.shift ?? false) !== e.shiftKey) return false;
-  if ((stroke.alt ?? false) !== e.altKey) return false;
-  const keys = Array.isArray(stroke.key) ? stroke.key : [stroke.key];
-  return keys.some(k => e.key.toLowerCase() === k.toLowerCase());
-}
+type ChordState = {
+  candidates: ChordBinding[];
+  timeoutId: ReturnType<typeof setTimeout>;
+};
 
 const CHORD_TIMEOUT_MS = 2000;
 
 let activeChordOwner: symbol | null = null;
 
-export function setupEditorKeyboardShortcuts(
+const hasCtrlOrMeta = (e: KeyboardEvent): boolean => e.ctrlKey || e.metaKey;
+
+const matchesStroke = (e: KeyboardEvent, stroke: StrokeSpec): boolean => {
+  if (stroke.ctrlOrMeta !== hasCtrlOrMeta(e)) return false;
+  if ((stroke.shift ?? false) !== e.shiftKey) return false;
+  if ((stroke.alt ?? false) !== e.altKey) return false;
+  const keys = Array.isArray(stroke.key) ? stroke.key : [stroke.key];
+  return keys.some(k => e.key.toLowerCase() === k.toLowerCase());
+};
+
+export const setupEditorKeyboardShortcuts = (
   editor: Editor,
   options: EditorShortcutOptions,
-): () => void {
+): (() => void) => {
   const { shortcuts = [], chords = [] } = options;
   const ownerId = Symbol();
 
-  let chordState: {
-    candidates: ChordBinding[];
-    timeoutId: ReturnType<typeof setTimeout>;
-  } | null = null;
+  let chordState: ChordState | null = null;
 
-  function clearChordState() {
+  const clearChordState = () => {
     if (chordState) {
       clearTimeout(chordState.timeoutId);
       chordState = null;
@@ -78,21 +58,18 @@ export function setupEditorKeyboardShortcuts(
     if (activeChordOwner === ownerId) {
       activeChordOwner = null;
     }
-  }
+  };
 
-  function handleChordKeyDown(e: KeyboardEvent) {
+  const handleChordKeyDown = (e: KeyboardEvent) => {
     if (chordState) {
       if (activeChordOwner !== ownerId) return;
-      for (const candidate of chordState.candidates) {
-        if (matchesStroke(e, candidate.second)) {
-          e.preventDefault();
-          e.stopPropagation();
-          clearChordState();
-          candidate.handler();
-          return;
-        }
-      }
+      const matched = chordState.candidates.find(c => matchesStroke(e, c.second));
       clearChordState();
+      if (matched) {
+        e.preventDefault();
+        e.stopPropagation();
+        matched.handler();
+      }
       return;
     }
 
@@ -109,21 +86,17 @@ export function setupEditorKeyboardShortcuts(
         timeoutId: setTimeout(clearChordState, CHORD_TIMEOUT_MS),
       };
     }
-  }
+  };
 
-  // Single-stroke handler on editor DOM node — unaffected by the chord bug.
-  function handleSingleKeyDown(e: KeyboardEvent) {
+  const handleSingleKeyDown = (e: KeyboardEvent) => {
     if (chordState) return;
-
-    for (const shortcut of shortcuts) {
-      if (matchesStroke(e, shortcut)) {
-        e.preventDefault();
-        e.stopPropagation();
-        shortcut.handler();
-        return;
-      }
+    const matched = shortcuts.find(s => matchesStroke(e, s));
+    if (matched) {
+      e.preventDefault();
+      e.stopPropagation();
+      matched.handler();
     }
-  }
+  };
 
   if (chords.length > 0) {
     document.addEventListener('keydown', handleChordKeyDown, true);
@@ -141,4 +114,4 @@ export function setupEditorKeyboardShortcuts(
       domNode.removeEventListener('keydown', handleSingleKeyDown, true);
     }
   };
-}
+};

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -1,0 +1,122 @@
+/**
+ * DOM-level keyboard shortcut handler for Monaco Editor.
+ *
+ * Monaco standalone uses `USLayoutResolvedKeybinding` which maps KeyCode values
+ * to physical US key positions. This breaks shortcuts like Ctrl+/ and Ctrl+- on
+ * non-US layouts (French AZERTY, German QWERTZ, etc.) where `/` and `-` are at
+ * different physical key positions.
+ *
+ * This module intercepts `keydown` events on the editor DOM and checks `event.key`
+ * (logical character) instead of `event.keyCode` (physical position), which works
+ * correctly regardless of keyboard layout.
+ */
+
+import type { Editor } from '../common/monaco';
+
+interface StrokeSpec {
+  key: string | string[];
+  ctrlOrMeta: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}
+
+interface ShortcutBinding extends StrokeSpec {
+  handler: () => void;
+}
+
+interface ChordBinding {
+  first: StrokeSpec;
+  second: StrokeSpec;
+  handler: () => void;
+}
+
+interface EditorShortcutOptions {
+  shortcuts?: ShortcutBinding[];
+  chords?: ChordBinding[];
+}
+
+function hasCtrlOrMeta(e: KeyboardEvent): boolean {
+  return e.ctrlKey || e.metaKey;
+}
+
+function matchesStroke(e: KeyboardEvent, stroke: StrokeSpec): boolean {
+  if (stroke.ctrlOrMeta && !hasCtrlOrMeta(e)) return false;
+  if (!stroke.ctrlOrMeta && hasCtrlOrMeta(e)) return false;
+  if ((stroke.shift ?? false) !== e.shiftKey) return false;
+  if ((stroke.alt ?? false) !== e.altKey) return false;
+  const keys = Array.isArray(stroke.key) ? stroke.key : [stroke.key];
+  return keys.some(k => e.key.toLowerCase() === k.toLowerCase());
+}
+
+const CHORD_TIMEOUT_MS = 2000;
+
+export function setupEditorKeyboardShortcuts(
+  editor: Editor,
+  options: EditorShortcutOptions,
+): () => void {
+  const { shortcuts = [], chords = [] } = options;
+
+  let chordState: {
+    chord: ChordBinding;
+    timeoutId: ReturnType<typeof setTimeout>;
+  } | null = null;
+
+  function clearChordState() {
+    if (chordState) {
+      clearTimeout(chordState.timeoutId);
+      chordState = null;
+    }
+  }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (chordState) {
+      const { chord } = chordState;
+      if (matchesStroke(e, chord.second)) {
+        e.preventDefault();
+        e.stopPropagation();
+        clearChordState();
+        chord.handler();
+        return;
+      }
+      clearChordState();
+    }
+
+    for (const chord of chords) {
+      if (matchesStroke(e, chord.first)) {
+        // Chord prefixes take precedence over single-stroke shortcuts.
+        // Example: when Ctrl/Cmd+K starts a chord, we consume it immediately
+        // so Monaco never sees that first stroke. If we later introduce a
+        // standalone Ctrl/Cmd+K binding, this ordering must be revisited.
+        e.preventDefault();
+        e.stopPropagation();
+        clearChordState();
+        chordState = {
+          chord,
+          timeoutId: setTimeout(clearChordState, CHORD_TIMEOUT_MS),
+        };
+        return;
+      }
+    }
+
+    for (const shortcut of shortcuts) {
+      if (matchesStroke(e, shortcut)) {
+        e.preventDefault();
+        e.stopPropagation();
+        shortcut.handler();
+        return;
+      }
+    }
+  }
+
+  const domNode = editor.getDomNode();
+  if (domNode) {
+    domNode.addEventListener('keydown', handleKeyDown, true);
+  }
+
+  return () => {
+    clearChordState();
+    if (domNode) {
+      domNode.removeEventListener('keydown', handleKeyDown, true);
+    }
+  };
+}

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -56,11 +56,14 @@ function matchesStroke(e: KeyboardEvent, stroke: StrokeSpec): boolean {
 
 const CHORD_TIMEOUT_MS = 2000;
 
+let activeChordOwner: symbol | null = null;
+
 export function setupEditorKeyboardShortcuts(
   editor: Editor,
   options: EditorShortcutOptions,
 ): () => void {
   const { shortcuts = [], chords = [] } = options;
+  const ownerId = Symbol();
 
   let chordState: {
     candidates: ChordBinding[];
@@ -72,12 +75,14 @@ export function setupEditorKeyboardShortcuts(
       clearTimeout(chordState.timeoutId);
       chordState = null;
     }
+    if (activeChordOwner === ownerId) {
+      activeChordOwner = null;
+    }
   }
 
-  // Chord handler on document — first stroke requires editor focus,
-  // second stroke fires regardless of target (handles WKWebView retargeting).
   function handleChordKeyDown(e: KeyboardEvent) {
     if (chordState) {
+      if (activeChordOwner !== ownerId) return;
       for (const candidate of chordState.candidates) {
         if (matchesStroke(e, candidate.second)) {
           e.preventDefault();
@@ -91,12 +96,14 @@ export function setupEditorKeyboardShortcuts(
       return;
     }
 
+    if (activeChordOwner !== null) return;
     if (!editor.hasTextFocus()) return;
 
     const candidates = chords.filter(chord => matchesStroke(e, chord.first));
     if (candidates.length > 0) {
       e.preventDefault();
       e.stopPropagation();
+      activeChordOwner = ownerId;
       chordState = {
         candidates,
         timeoutId: setTimeout(clearChordState, CHORD_TIMEOUT_MS),

--- a/src/views/connect/index.vue
+++ b/src/views/connect/index.vue
@@ -32,9 +32,16 @@
       </template>
       <template v-else>
         <div class="es-editor">
-          <tool-bar type="ES_EDITOR" @insert-sample-query="handleInsertSampleQuery" />
+          <tool-bar
+            :ref="el => setToolBarRef(el, panel.id)"
+            type="ES_EDITOR"
+            @insert-sample-query="handleInsertSampleQuery"
+          />
           <div class="es-editor-container">
-            <es-editor :ref="el => setEditorRef(el, panel.id)" />
+            <es-editor
+              :ref="el => setEditorRef(el, panel.id)"
+              @toggle-shortcuts-dialog="handleToggleShortcutsDialog"
+            />
           </div>
         </div>
       </template>
@@ -65,6 +72,7 @@ const { establishPanel, closePanel, setActivePanel, checkFileExists } = tabStore
 const { panels, activePanel } = storeToRefs(tabStore);
 
 const esEditorRefs = new Map<number, InstanceType<typeof EsEditor>>();
+const toolBarRefs = new Map<number, InstanceType<typeof ToolBar>>();
 
 const setEditorRef = (el: any, panelId: number) => {
   if (el) {
@@ -74,9 +82,21 @@ const setEditorRef = (el: any, panelId: number) => {
   }
 };
 
+const setToolBarRef = (el: any, panelId: number) => {
+  if (el) {
+    toolBarRefs.set(panelId, el);
+  } else {
+    toolBarRefs.delete(panelId);
+  }
+};
+
 const handleInsertSampleQuery = (query: string) => {
   const editor = esEditorRefs.get(activePanel.value.id);
   editor?.insertSampleQuery(query);
+};
+
+const handleToggleShortcutsDialog = () => {
+  toolBarRefs.get(activePanel.value.id)?.toggleShortcutsDialog();
 };
 
 const tabPanelHandler = async ({

--- a/src/views/connect/index.vue
+++ b/src/views/connect/index.vue
@@ -27,7 +27,7 @@
       <connect-list v-if="panel.id === 0" @tab-panel="tabPanelHandler" />
       <template v-else-if="panel.connection && panel.connection.type === DatabaseType.DYNAMODB">
         <div class="dynamo-editor">
-          <dynamo-editor />
+          <dynamo-editor :ref="el => setDynamoEditorRef(el, panel.id)" />
         </div>
       </template>
       <template v-else>
@@ -38,10 +38,7 @@
             @insert-sample-query="handleInsertSampleQuery"
           />
           <div class="es-editor-container">
-            <es-editor
-              :ref="el => setEditorRef(el, panel.id)"
-              @toggle-shortcuts-dialog="handleToggleShortcutsDialog"
-            />
+            <es-editor :ref="el => setEditorRef(el, panel.id)" />
           </div>
         </div>
       </template>
@@ -60,7 +57,7 @@ import DynamoEditor from '../editor/dynamo-editor/index.vue';
 import ToolBar from '../../components/tool-bar.vue';
 import { useLang } from '../../lang';
 import { CustomError } from '../../common';
-import { useDialogService, useMessageService } from '@/composables';
+import { useDialogService, useMessageService, setupGlobalShortcuts } from '@/composables';
 
 const route = useRoute();
 const dialog = useDialogService();
@@ -73,6 +70,8 @@ const { panels, activePanel } = storeToRefs(tabStore);
 
 const esEditorRefs = new Map<number, InstanceType<typeof EsEditor>>();
 const toolBarRefs = new Map<number, InstanceType<typeof ToolBar>>();
+const dynamoEditorRefs = new Map<number, InstanceType<typeof DynamoEditor>>();
+let cleanupGlobalShortcuts: (() => void) | null = null;
 
 const setEditorRef = (el: any, panelId: number) => {
   if (el) {
@@ -90,13 +89,27 @@ const setToolBarRef = (el: any, panelId: number) => {
   }
 };
 
+const setDynamoEditorRef = (el: any, panelId: number) => {
+  if (el) {
+    dynamoEditorRefs.set(panelId, el);
+  } else {
+    dynamoEditorRefs.delete(panelId);
+  }
+};
+
 const handleInsertSampleQuery = (query: string) => {
   const editor = esEditorRefs.get(activePanel.value.id);
   editor?.insertSampleQuery(query);
 };
 
 const handleToggleShortcutsDialog = () => {
-  toolBarRefs.get(activePanel.value.id)?.toggleShortcutsDialog();
+  const panelId = activePanel.value.id;
+  const esToolBar = toolBarRefs.get(panelId);
+  if (esToolBar) {
+    esToolBar.toggleShortcutsDialog();
+  } else {
+    dynamoEditorRefs.get(panelId)?.toggleShortcutsDialog();
+  }
 };
 
 const tabPanelHandler = async ({
@@ -149,9 +162,26 @@ const handleTabChange = async (panelName: string, action: 'CHANGE' | 'CLOSE') =>
 };
 
 onMounted(async () => {
+  // Global shortcuts work when any editor tab is active (not the connect-list)
+  cleanupGlobalShortcuts = setupGlobalShortcuts({
+    shortcuts: [
+      {
+        key: ['/', '?'],
+        ctrlOrMeta: true,
+        shift: true,
+        handler: handleToggleShortcutsDialog,
+      },
+    ],
+    isActive: () => activePanel.value.id !== 0,
+  });
+
   if (route.params.filePath && route.params.filePath !== ':filePath') {
     await establishPanel(route.params.filePath as string);
   }
+});
+
+onUnmounted(() => {
+  cleanupGlobalShortcuts?.();
 });
 </script>
 

--- a/src/views/editor/dynamo-editor/components/sql-editor.vue
+++ b/src/views/editor/dynamo-editor/components/sql-editor.vue
@@ -642,9 +642,11 @@ const setupEditor = () => {
     });
   }
 
-  // Layout-dependent shortcuts (/, -) are handled via DOM keydown events
+  // Layout-dependent shortcuts (/) are handled via DOM keydown events
   // instead of Monaco's addCommand, which assumes US keyboard layout.
+  // Chord shortcuts (Ctrl+K,Ctrl+0 / Ctrl+K,Ctrl+J) also use DOM events to share chord state.
   // See: src/composables/useKeyboardShortcuts.ts
+  // Note: Ctrl/Cmd+Shift+/ (show shortcuts dialog) is handled globally at connect/index.vue
   cleanupKeyboardShortcuts = setupEditorKeyboardShortcuts(editor, {
     shortcuts: [
       {
@@ -652,17 +654,15 @@ const setupEditor = () => {
         ctrlOrMeta: true,
         handler: () => editor!.trigger('keyboard', 'editor.action.commentLine', {}),
       },
-      {
-        key: ['/', '?'],
-        ctrlOrMeta: true,
-        shift: true,
-        handler: () => emits('toggle-shortcuts-dialog'),
-      },
     ],
     chords: [
       {
+        // Fold All Except Current: Ctrl/Cmd+K, Ctrl/Cmd+0
+        // Uses '0' (like VS Code's Fold All) — works on all keyboard layouts
+        // unlike '-' which requires Shift on AZERTY, or 'f' which conflicts
+        // with Monaco's built-in Format Selection (Ctrl/Cmd+K, Ctrl/Cmd+F)
         first: { key: 'k', ctrlOrMeta: true },
-        second: { key: '-', ctrlOrMeta: true },
+        second: { key: '0', ctrlOrMeta: true },
         handler: () => {
           editor!.trigger('keyboard', 'editor.foldAll', {});
           editor!.trigger('keyboard', 'editor.unfoldRecursively', {});
@@ -755,8 +755,6 @@ onUnmounted(async () => {
   }
   editor?.dispose();
 });
-
-const emits = defineEmits(['toggle-shortcuts-dialog']);
 
 // Expose methods for parent component
 defineExpose({

--- a/src/views/editor/dynamo-editor/components/sql-editor.vue
+++ b/src/views/editor/dynamo-editor/components/sql-editor.vue
@@ -79,6 +79,7 @@ import {
   setPartiqlDynamicOptions,
   validatePartiqlModel,
 } from '../../../../common/monaco';
+import { setupEditorKeyboardShortcuts } from '../../../../composables';
 import type { PartiqlDecoration, PartiqlStatement } from '../../../../common/monaco/partiql';
 import { useLang } from '../../../../lang';
 import {
@@ -112,6 +113,7 @@ const historyStore = useHistoryStore();
 const partiqlData = computed(() => dynamoData.value.partiqlData);
 
 let editor: Editor | null = null;
+let cleanupKeyboardShortcuts: (() => void) | null = null;
 const editorRef = ref<HTMLElement>();
 const editorSize = ref(partiqlData.value.showResultPanel ? 0.5 : 1);
 const loadingRef = ref(false);
@@ -629,28 +631,6 @@ const setupEditor = () => {
     });
   }
 
-  // Fold All Except Current: Ctrl/Cmd+K, Ctrl/Cmd+Minus (VS Code default — chorded, works on all platforms)
-  editor.addCommand(
-    monaco.KeyMod.chord(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Minus,
-    ),
-    () => {
-      editor!.trigger('keyboard', 'editor.foldAll', {});
-      editor!.trigger('keyboard', 'editor.unfoldRecursively', {});
-    },
-  );
-  // Unfold All: Ctrl/Cmd+K, Ctrl/Cmd+J (VS Code default — chorded, works on all platforms)
-  editor.addCommand(
-    monaco.KeyMod.chord(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyJ,
-    ),
-    () => {
-      editor!.trigger('keyboard', 'editor.unfoldAll', {});
-    },
-  );
-
   /**
    * Save file (Ctrl+S or Cmd+S on Windows only)
    * On macOS and Linux, the OS handles Cmd+S/Ctrl+S natively via the saveFile event
@@ -661,6 +641,42 @@ const setupEditor = () => {
       saveModelContent(true, true, true);
     });
   }
+
+  // Layout-dependent shortcuts (/, -) are handled via DOM keydown events
+  // instead of Monaco's addCommand, which assumes US keyboard layout.
+  // See: src/composables/useKeyboardShortcuts.ts
+  cleanupKeyboardShortcuts = setupEditorKeyboardShortcuts(editor, {
+    shortcuts: [
+      {
+        key: '/',
+        ctrlOrMeta: true,
+        handler: () => editor!.trigger('keyboard', 'editor.action.commentLine', {}),
+      },
+      {
+        key: ['/', '?'],
+        ctrlOrMeta: true,
+        shift: true,
+        handler: () => emits('toggle-shortcuts-dialog'),
+      },
+    ],
+    chords: [
+      {
+        first: { key: 'k', ctrlOrMeta: true },
+        second: { key: '-', ctrlOrMeta: true },
+        handler: () => {
+          editor!.trigger('keyboard', 'editor.foldAll', {});
+          editor!.trigger('keyboard', 'editor.unfoldRecursively', {});
+        },
+      },
+      {
+        first: { key: 'k', ctrlOrMeta: true },
+        second: { key: 'j', ctrlOrMeta: true },
+        handler: () => {
+          editor!.trigger('keyboard', 'editor.unfoldAll', {});
+        },
+      },
+    ],
+  });
 
   // Update dynamic options for autocomplete
   if (activeConnection.value) {
@@ -730,6 +746,8 @@ onUnmounted(async () => {
   await cleanupFileListener();
   // Remove document click listener
   document.removeEventListener('click', handleDocumentClick);
+  // Clean up DOM keyboard shortcut listeners
+  cleanupKeyboardShortcuts?.();
   // Clear validation markers before disposing
   const model = editor?.getModel();
   if (model) {
@@ -737,6 +755,8 @@ onUnmounted(async () => {
   }
   editor?.dispose();
 });
+
+const emits = defineEmits(['toggle-shortcuts-dialog']);
 
 // Expose methods for parent component
 defineExpose({

--- a/src/views/editor/dynamo-editor/index.vue
+++ b/src/views/editor/dynamo-editor/index.vue
@@ -1,17 +1,23 @@
 <template>
   <div class="dynamo-editor">
     <tool-bar
+      ref="toolBarRef"
       type="DYNAMO_EDITOR"
       @insert-partiql-sample="handleInsertPartiqlSample"
       @execute-partiql-query="handleExecutePartiqlQuery"
     />
     <ui-editor v-if="activePanel.editorType === 'DYNAMO_EDITOR_UI'"></ui-editor>
     <create-item v-else-if="activePanel.editorType === 'DYNAMO_EDITOR_CREATE_ITEM'" />
-    <sql-editor v-else :ref="el => setSqlEditorRef(el)" />
+    <sql-editor
+      v-else
+      :ref="el => setSqlEditorRef(el)"
+      @toggle-shortcuts-dialog="handleToggleShortcutsDialog"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import ToolBar from '../../../components/tool-bar.vue';
 import UiEditor from './components/ui-editor.vue';
@@ -22,6 +28,7 @@ import { useTabStore } from '../../../store';
 const tabStore = useTabStore();
 const { activePanel } = storeToRefs(tabStore);
 
+const toolBarRef = ref<InstanceType<typeof ToolBar>>();
 let sqlEditorRef: InstanceType<typeof SqlEditor> | null = null;
 
 const setSqlEditorRef = (el: any) => {
@@ -38,6 +45,10 @@ const handleExecutePartiqlQuery = () => {
   if (sqlEditorRef) {
     sqlEditorRef.executeQuery();
   }
+};
+
+const handleToggleShortcutsDialog = () => {
+  toolBarRef.value?.toggleShortcutsDialog();
 };
 </script>
 

--- a/src/views/editor/dynamo-editor/index.vue
+++ b/src/views/editor/dynamo-editor/index.vue
@@ -8,11 +8,7 @@
     />
     <ui-editor v-if="activePanel.editorType === 'DYNAMO_EDITOR_UI'"></ui-editor>
     <create-item v-else-if="activePanel.editorType === 'DYNAMO_EDITOR_CREATE_ITEM'" />
-    <sql-editor
-      v-else
-      :ref="el => setSqlEditorRef(el)"
-      @toggle-shortcuts-dialog="handleToggleShortcutsDialog"
-    />
+    <sql-editor v-else :ref="el => setSqlEditorRef(el)" />
   </div>
 </template>
 
@@ -47,9 +43,9 @@ const handleExecutePartiqlQuery = () => {
   }
 };
 
-const handleToggleShortcutsDialog = () => {
-  toolBarRef.value?.toggleShortcutsDialog();
-};
+defineExpose({
+  toggleShortcutsDialog: () => toolBarRef.value?.toggleShortcutsDialog(),
+});
 </script>
 
 <style scoped></style>

--- a/src/views/editor/es-editor/index.vue
+++ b/src/views/editor/es-editor/index.vue
@@ -474,7 +474,7 @@ const setupQueryEditor = () => {
     });
   }
 
-  // Fold All Except Current: Ctrl/Cmd+K, Ctrl/Cmd+- (handled via DOM-level keydown for keyboard layout compatibility)
+  // Fold All Except Current: Ctrl/Cmd+K, Ctrl/Cmd+0 (handled via DOM-level keydown)
   // Unfold All: Ctrl/Cmd+K, Ctrl/Cmd+J (also handled via DOM-level keydown to share chord state with fold-all)
 
   // Open ES API doc: ⌘+D on Mac, Ctrl+D on Windows/Linux
@@ -491,9 +491,11 @@ const setupQueryEditor = () => {
     });
   }
 
-  // Layout-dependent shortcuts (/, -) are handled via DOM keydown events
+  // Layout-dependent shortcuts (/) are handled via DOM keydown events
   // instead of Monaco's addCommand, which assumes US keyboard layout.
+  // Chord shortcuts (Ctrl+K,Ctrl+0 / Ctrl+K,Ctrl+J) also use DOM events to share chord state.
   // See: src/composables/useKeyboardShortcuts.ts
+  // Note: Ctrl/Cmd+Shift+/ (show shortcuts dialog) is handled globally at connect/index.vue
   cleanupKeyboardShortcuts = setupEditorKeyboardShortcuts(queryEditor, {
     shortcuts: [
       {
@@ -501,17 +503,15 @@ const setupQueryEditor = () => {
         ctrlOrMeta: true,
         handler: () => queryEditor!.trigger('keyboard', 'editor.action.commentLine', {}),
       },
-      {
-        key: ['/', '?'],
-        ctrlOrMeta: true,
-        shift: true,
-        handler: () => emits('toggle-shortcuts-dialog'),
-      },
     ],
     chords: [
       {
+        // Fold All Except Current: Ctrl/Cmd+K, Ctrl/Cmd+0
+        // Uses '0' (like VS Code's Fold All) — works on all keyboard layouts
+        // unlike '-' which requires Shift on AZERTY, or 'f' which conflicts
+        // with Monaco's built-in Format Selection (Ctrl/Cmd+K, Ctrl/Cmd+F)
         first: { key: 'k', ctrlOrMeta: true },
-        second: { key: '-', ctrlOrMeta: true },
+        second: { key: '0', ctrlOrMeta: true },
         handler: () => {
           queryEditor!.trigger('keyboard', 'editor.foldAll', {});
           queryEditor!.trigger('keyboard', 'editor.unfoldRecursively', {});
@@ -618,8 +618,6 @@ const insertSampleQuery = (queryTemplate: string) => {
   queryEditor.setPosition({ lineNumber: newLineNumber, column: 1 });
   queryEditor.revealLine(newLineNumber);
 };
-
-const emits = defineEmits(['toggle-shortcuts-dialog']);
 
 defineExpose({
   insertSampleQuery,

--- a/src/views/editor/es-editor/index.vue
+++ b/src/views/editor/es-editor/index.vue
@@ -69,6 +69,7 @@ import {
   clearEsValidation,
   createDebouncedValidator,
 } from '../../../common/monaco';
+import { setupEditorKeyboardShortcuts } from '../../../composables';
 
 const appStore = useAppStore();
 const message = useMessageService();
@@ -96,6 +97,7 @@ const queryEditorRef = ref();
 const displayRef = ref();
 
 let executeDecorations: Array<Decoration | string> = [];
+let cleanupKeyboardShortcuts: (() => void) | null = null;
 
 // Monaco editor target type for gutter line decorations
 // See: https://microsoft.github.io/monaco-editor/api/enums/editor.MouseTargetType.html
@@ -472,27 +474,8 @@ const setupQueryEditor = () => {
     });
   }
 
-  // Fold All Except Current: Ctrl/Cmd+K, Ctrl/Cmd+Minus (VS Code default — chorded, works on all platforms)
-  queryEditor.addCommand(
-    monaco.KeyMod.chord(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Minus,
-    ),
-    () => {
-      queryEditor!.trigger('keyboard', 'editor.foldAll', {});
-      queryEditor!.trigger('keyboard', 'editor.unfoldRecursively', {});
-    },
-  );
-  // Unfold All: Ctrl/Cmd+K, Ctrl/Cmd+J (VS Code default — chorded, works on all platforms)
-  queryEditor.addCommand(
-    monaco.KeyMod.chord(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyJ,
-    ),
-    () => {
-      queryEditor!.trigger('keyboard', 'editor.unfoldAll', {});
-    },
-  );
+  // Fold All Except Current: Ctrl/Cmd+K, Ctrl/Cmd+- (handled via DOM-level keydown for keyboard layout compatibility)
+  // Unfold All: Ctrl/Cmd+K, Ctrl/Cmd+J (also handled via DOM-level keydown to share chord state with fold-all)
 
   // Open ES API doc: ⌘+D on Mac, Ctrl+D on Windows/Linux
   queryEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyD, () => {
@@ -507,6 +490,42 @@ const setupQueryEditor = () => {
       saveModelContent(true, true, true);
     });
   }
+
+  // Layout-dependent shortcuts (/, -) are handled via DOM keydown events
+  // instead of Monaco's addCommand, which assumes US keyboard layout.
+  // See: src/composables/useKeyboardShortcuts.ts
+  cleanupKeyboardShortcuts = setupEditorKeyboardShortcuts(queryEditor, {
+    shortcuts: [
+      {
+        key: '/',
+        ctrlOrMeta: true,
+        handler: () => queryEditor!.trigger('keyboard', 'editor.action.commentLine', {}),
+      },
+      {
+        key: ['/', '?'],
+        ctrlOrMeta: true,
+        shift: true,
+        handler: () => emits('toggle-shortcuts-dialog'),
+      },
+    ],
+    chords: [
+      {
+        first: { key: 'k', ctrlOrMeta: true },
+        second: { key: '-', ctrlOrMeta: true },
+        handler: () => {
+          queryEditor!.trigger('keyboard', 'editor.foldAll', {});
+          queryEditor!.trigger('keyboard', 'editor.unfoldRecursively', {});
+        },
+      },
+      {
+        first: { key: 'k', ctrlOrMeta: true },
+        second: { key: 'j', ctrlOrMeta: true },
+        handler: () => {
+          queryEditor!.trigger('keyboard', 'editor.unfoldAll', {});
+        },
+      },
+    ],
+  });
 };
 
 const queryEditorSize = ref(1);
@@ -600,6 +619,8 @@ const insertSampleQuery = (queryTemplate: string) => {
   queryEditor.revealLine(newLineNumber);
 };
 
+const emits = defineEmits(['toggle-shortcuts-dialog']);
+
 defineExpose({
   insertSampleQuery,
 });
@@ -622,6 +643,7 @@ onMounted(async () => {
 
 onUnmounted(async () => {
   await cleanupFileListener();
+  cleanupKeyboardShortcuts?.();
   // Remove document click listener
   document.removeEventListener('click', handleDocumentClick);
   // Clear validation markers before disposing


### PR DESCRIPTION
This pull request introduces a robust, layout-independent keyboard shortcut system for the editor and global app actions, improving cross-platform and international keyboard support. It refactors shortcut handling out of component files and into composable utility modules, ensures correct shortcut display and behavior regardless of keyboard layout, and cleans up legacy code. The most important changes are:

**Keyboard Shortcut Infrastructure:**

* Added `setupEditorKeyboardShortcuts` and `setupGlobalShortcuts` composables to handle editor-specific and global keyboard shortcuts, respectively, using logical key values for layout independence and supporting both single and chorded shortcuts. (`src/composables/useKeyboardShortcuts.ts`, `src/composables/useGlobalShortcuts.ts`, `src/composables/index.ts`) [[1]](diffhunk://#diff-47676ea456a5154f91ffffbff6f829c3ec89463a0143fa486fb140526ed4af6bR1-R137) [[2]](diffhunk://#diff-730b719871da0f6a9c2cbac7f6d06a019b10c2981338ce28d87c77529ad99df0R1-R61) [[3]](diffhunk://#diff-4f5e621aba56ce3c342300743879d7fdb39f1f3c3ca8b866d6baec98caa2e4bfR13-R14)

**Editor Component Refactoring:**

* Refactored DynamoDB and Elasticsearch editor components to use the new shortcut composables, removing Monaco's US-layout-dependent `addCommand` calls and wiring up cleanup for event listeners. (`src/views/editor/dynamo-editor/components/sql-editor.vue`, `src/views/editor/es-editor/index.vue`) [[1]](diffhunk://#diff-942e3ea8d3457be8f96994d6e6e23c712e376b313a759ebc080ffd7060ff984aL632-L653) [[2]](diffhunk://#diff-942e3ea8d3457be8f96994d6e6e23c712e376b313a759ebc080ffd7060ff984aR645-R680) [[3]](diffhunk://#diff-942e3ea8d3457be8f96994d6e6e23c712e376b313a759ebc080ffd7060ff984aR749-R750) [[4]](diffhunk://#diff-408b9345ac976a3b3c477cef986abf6cc416d336cc836eb11f74679e7ab2c213R72) [[5]](diffhunk://#diff-408b9345ac976a3b3c477cef986abf6cc416d336cc836eb11f74679e7ab2c213R100)

**Global Shortcut Handling:**

* Moved the "Show Shortcuts Dialog" (Ctrl/Cmd+Shift+/) handling to a global shortcut handler, so it works regardless of editor focus, and exposed a `toggleShortcutsDialog` method from toolbars/editors for parent control. (`src/views/connect/index.vue`, `src/components/tool-bar.vue`, `src/views/editor/dynamo-editor/index.vue`) [[1]](diffhunk://#diff-3b3bc58b7cf79632729fa2cc10cf8f566b11fb3613953db9d06558dcdf74899bL56-R60) [[2]](diffhunk://#diff-3b3bc58b7cf79632729fa2cc10cf8f566b11fb3613953db9d06558dcdf74899bR72-R74) [[3]](diffhunk://#diff-3b3bc58b7cf79632729fa2cc10cf8f566b11fb3613953db9d06558dcdf74899bR84-R114) [[4]](diffhunk://#diff-3b3bc58b7cf79632729fa2cc10cf8f566b11fb3613953db9d06558dcdf74899bR165-R185) [[5]](diffhunk://#diff-41529f6c831b85b601d7be26f3a5b99e5e80914851b3e9f3bcac05527d28cc52R308-R314) [[6]](diffhunk://#diff-10183cb818ff2370bf5944e8c87153ff001cb3213eceb73f02758e766b040daaR4) [[7]](diffhunk://#diff-10183cb818ff2370bf5944e8c87153ff001cb3213eceb73f02758e766b040daaR16) [[8]](diffhunk://#diff-10183cb818ff2370bf5944e8c87153ff001cb3213eceb73f02758e766b040daaR27) [[9]](diffhunk://#diff-10183cb818ff2370bf5944e8c87153ff001cb3213eceb73f02758e766b040daaR45-R48)

**Shortcut Display and Documentation:**

* Updated the shortcuts help dialog and toolbar hints to accurately reflect the new, layout-agnostic shortcuts (e.g., using `?` instead of `Shift+/`, and `0` instead of `-` for folding all). (`src/components/shortcuts-help-dialog.vue`) [[1]](diffhunk://#diff-a08fb96e2630447661a4d7a16903f7d34b6426996da3dd60b0c1b3e539b3e691L20-R20) [[2]](diffhunk://#diff-a08fb96e2630447661a4d7a16903f7d34b6426996da3dd60b0c1b3e539b3e691L81-R79)

**Legacy Code Cleanup:**

* Removed old, inline keyboard shortcut listeners from the toolbar and replaced them with the new composable-based approach. (`src/components/tool-bar.vue`)

These changes make keyboard shortcuts more reliable, maintainable, and accessible for all users, regardless of platform or keyboard layout.

Refs: #355 
