### PR TITLE
feat(completion): add query parameter value autocomplete 

### DIFF
--- a/src/common/monaco/searchdsl/apiSpec.ts
+++ b/src/common/monaco/searchdsl/apiSpec.ts
@@ -97,6 +97,36 @@ const commonEndpoints: ApiEndpoint[] = [
     description: 'Execute a search query on a specific index',
     descriptionKey: 'grammar.searchIndex',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name(s)', required: true }],
+    queryParams: [
+      { name: 'q', type: 'string', description: 'Query in the Lucene query string syntax' },
+      { name: 'df', type: 'string', description: 'Default field for query string' },
+      { name: 'analyzer', type: 'string', description: 'Analyzer to use for query string' },
+      {
+        name: 'default_operator',
+        type: 'string',
+        description: 'Default operator for query string',
+        enum: ['AND', 'OR'],
+      },
+      { name: 'from', type: 'integer', description: 'Starting offset', default: 0 },
+      { name: 'size', type: 'integer', description: 'Number of hits to return', default: 10 },
+      { name: 'sort', type: 'string', description: 'Sort order' },
+      { name: 'timeout', type: 'string', description: 'Search timeout' },
+      {
+        name: 'terminate_after',
+        type: 'integer',
+        description: 'Maximum number of documents to collect',
+      },
+      { name: 'track_total_hits', type: 'boolean', description: 'Track total number of hits' },
+      {
+        name: 'search_type',
+        type: 'string',
+        description: 'Search type',
+        enum: ['query_then_fetch', 'dfs_query_then_fetch'],
+      },
+      { name: 'request_cache', type: 'boolean', description: 'Enable request cache' },
+      { name: 'routing', type: 'string', description: 'Routing value' },
+      { name: 'preference', type: 'string', description: 'Execution preference' },
+    ],
   },
 
   // Count API
@@ -124,6 +154,18 @@ const commonEndpoints: ApiEndpoint[] = [
     description: 'Count documents in a specific index',
     descriptionKey: 'grammar.countIndex',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name(s)', required: true }],
+    queryParams: [
+      { name: 'q', type: 'string', description: 'Query in the Lucene query string syntax' },
+      { name: 'df', type: 'string', description: 'Default field for query string' },
+      { name: 'analyzer', type: 'string', description: 'Analyzer to use for query string' },
+      {
+        name: 'default_operator',
+        type: 'string',
+        description: 'Default operator',
+        enum: ['AND', 'OR'],
+      },
+      { name: 'routing', type: 'string', description: 'Routing value' },
+    ],
   },
 
   // Document APIs
@@ -153,6 +195,24 @@ const commonEndpoints: ApiEndpoint[] = [
     pathParams: [
       { name: 'index', type: 'string', description: 'Index name', required: true },
       { name: 'id', type: 'string', description: 'Document ID', required: true },
+    ],
+    queryParams: [
+      { name: 'routing', type: 'string', description: 'Routing value' },
+      { name: 'preference', type: 'string', description: 'Execution preference' },
+      { name: 'realtime', type: 'boolean', description: 'Realtime get' },
+      {
+        name: 'version',
+        type: 'integer',
+        description: 'Document version for optimistic concurrency',
+      },
+      { name: '_source', type: 'string', description: 'Source fields to return' },
+      {
+        name: 'refresh',
+        type: 'string',
+        description: 'Refresh policy',
+        enum: ['true', 'false', 'wait_for'],
+      },
+      { name: 'timeout', type: 'string', description: 'Operation timeout' },
     ],
   },
   {
@@ -200,6 +260,17 @@ const commonEndpoints: ApiEndpoint[] = [
     description: 'Perform bulk operations on a specific index',
     pathParams: [
       { name: 'index', type: 'string', description: 'Default index name', required: true },
+    ],
+    queryParams: [
+      {
+        name: 'refresh',
+        type: 'string',
+        description: 'Refresh policy',
+        enum: ['true', 'false', 'wait_for'],
+      },
+      { name: 'routing', type: 'string', description: 'Default routing' },
+      { name: 'timeout', type: 'string', description: 'Operation timeout' },
+      { name: 'pipeline', type: 'string', description: 'Default ingest pipeline' },
     ],
   },
 
@@ -1218,13 +1289,11 @@ export class ApiSpecProvider {
    * Match a path against an endpoint pattern
    */
   private matchPath(pattern: string, path: string): boolean {
-    // Convert pattern to regex
-    const regexPattern = pattern
-      .replace(/\{[^}]+\}/g, '[^/]+') // Replace {param} with [^/]+
-      .replace(/\//g, '\\/'); // Escape slashes
-
-    const regex = new RegExp(`^${regexPattern}$`);
-    return regex.test(path);
+    const normalize = (p: string) => p.replace(/^\//, '');
+    const regexPattern = normalize(pattern)
+      .replace(/\{[^}]+\}/g, '[^/]+')
+      .replace(/\//g, '\\/');
+    return new RegExp(`^${regexPattern}$`).test(normalize(path));
   }
 
   /**

--- a/src/common/monaco/searchdsl/completionProvider.ts
+++ b/src/common/monaco/searchdsl/completionProvider.ts
@@ -140,7 +140,7 @@ const getCompletionContext = (
           .filter(Boolean)
       : [];
 
-    const valueMatch = /[?&]([^&=]+)=$/.exec(textUntilPosition);
+    const valueMatch = /[?&]([^&=]+)=[^&]*$/.exec(textUntilPosition);
     if (valueMatch) {
       return {
         backend: currentConfig.backend,
@@ -155,7 +155,8 @@ const getCompletionContext = (
 
     const paramNameMatch = /[?&][^=&]*$/.test(textUntilPosition);
     if (paramNameMatch) {
-      const completeParams = typedParams.slice(0, -1);
+      const partialName = /[?&]([^=&]*)$/.exec(textUntilPosition)?.[1] ?? '';
+      const completeParams = partialName.length > 0 ? typedParams.slice(0, -1) : typedParams;
       return {
         backend: currentConfig.backend,
         version: currentConfig.version,

--- a/src/common/monaco/searchdsl/completionProvider.ts
+++ b/src/common/monaco/searchdsl/completionProvider.ts
@@ -125,21 +125,46 @@ const getCompletionContext = (
     };
   }
 
-  // Check if we're completing query parameters (path contains ?)
-  // Use textUntilPosition to preserve spaces
-  const queryParamMatch = /^(GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS)\s+(\S+\?[^?\s]*)$/i.exec(
+  const queryStringMatch = /^(GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS)\s+([^\s?]+\?[^\s]*)$/i.exec(
     textUntilPosition,
   );
-  if (queryParamMatch) {
-    const fullPath = queryParamMatch[2];
-    const [basePath] = fullPath.split('?');
-    return {
-      backend: currentConfig.backend,
-      version: currentConfig.version,
-      position: 'queryParam',
-      method: queryParamMatch[1].toUpperCase() as HttpMethod,
-      path: basePath,
-    };
+  if (queryStringMatch) {
+    const method = queryStringMatch[1].toUpperCase() as HttpMethod;
+    const fullQueryString = queryStringMatch[2];
+    const [basePath, paramString] = fullQueryString.split('?');
+
+    const typedParams = paramString
+      ? paramString
+          .split('&')
+          .map(p => p.split('=')[0])
+          .filter(Boolean)
+      : [];
+
+    const valueMatch = /[?&]([^&=]+)=$/.exec(textUntilPosition);
+    if (valueMatch) {
+      return {
+        backend: currentConfig.backend,
+        version: currentConfig.version,
+        position: 'queryParamValue',
+        method,
+        path: basePath,
+        currentParam: valueMatch[1],
+        typedParams,
+      };
+    }
+
+    const paramNameMatch = /[?&][^=&]*$/.test(textUntilPosition);
+    if (paramNameMatch) {
+      const completeParams = typedParams.slice(0, -1);
+      return {
+        backend: currentConfig.backend,
+        version: currentConfig.version,
+        position: 'queryParam',
+        method,
+        path: basePath,
+        typedParams: completeParams,
+      };
+    }
   }
 
   // If we have a complete method followed by space, we're completing path
@@ -603,6 +628,7 @@ const provideQueryParamCompletions = (
   if (!endpoint?.queryParams) return completions;
 
   for (const param of endpoint.queryParams) {
+    if (context.typedParams?.includes(param.name)) continue;
     const insertText = createQueryParamInsertText(param);
 
     completions.push({
@@ -620,9 +646,36 @@ const provideQueryParamCompletions = (
   return completions;
 };
 
-/**
- * Create insert text for a query parameter
- */
+const provideQueryParamValueCompletions = (
+  context: CompletionContext,
+  range: monaco.Range,
+): monaco.languages.CompletionItem[] => {
+  const { backend, version, method, path, currentParam } = context;
+  if (!path || !currentParam) return [];
+
+  const endpoint = apiSpecProvider.findEndpoint(backend, path, method, version);
+  const param = endpoint?.queryParams?.find(p => p.name === currentParam);
+  if (!param) return [];
+
+  const values: string[] =
+    param.enum && param.enum.length > 0
+      ? param.enum
+      : param.type === 'boolean'
+        ? ['true', 'false']
+        : [];
+
+  return values.map(v => ({
+    label: v,
+    kind: monaco.languages.CompletionItemKind.Value,
+    insertText: v,
+    insertTextRules: monaco.languages.CompletionItemInsertTextRule.None,
+    detail: `${param.name} value`,
+    documentation: param.description,
+    sortText: v,
+    range,
+  }));
+};
+
 const createQueryParamInsertText = (param: QueryParam): string => {
   if (param.enum && param.enum.length > 0) {
     // For enum params, provide first value as placeholder
@@ -1669,6 +1722,9 @@ export const grammarCompletionProvider = (
       break;
     case 'queryParam':
       suggestions = provideQueryParamCompletions(context, defaultRange);
+      break;
+    case 'queryParamValue':
+      suggestions = provideQueryParamValueCompletions(context, defaultRange);
       break;
   }
 

--- a/src/common/monaco/searchdsl/index.ts
+++ b/src/common/monaco/searchdsl/index.ts
@@ -26,7 +26,7 @@ const registerSearchLanguage = (monaco: typeof import('monaco-editor')): void =>
     search.languageConfiguration as languages.LanguageConfiguration,
   );
   monaco.languages.registerCompletionItemProvider(search.id, {
-    triggerCharacters: ['g', 'p', 'd', '"', "'", ' ', '/', '_', ':'],
+    triggerCharacters: ['g', 'p', 'd', '"', "'", ' ', '/', '_', ':', '?', '&', '='],
     // @ts-ignore
     provideCompletionItems: searchCompletionProvider,
   });

--- a/src/common/monaco/searchdsl/types.ts
+++ b/src/common/monaco/searchdsl/types.ts
@@ -91,10 +91,12 @@ export type BodyProperty = {
 export type CompletionContext = {
   backend: BackendType;
   version?: string;
-  position: 'method' | 'path' | 'queryParam' | 'body';
+  position: 'method' | 'path' | 'queryParam' | 'queryParamValue' | 'body';
   method?: HttpMethod;
   path?: string;
   bodyPath?: string[];
+  currentParam?: string;
+  typedParams?: string[];
 };
 
 /**

--- a/tests/common/monaco/searchdsl/completionProvider.test.ts
+++ b/tests/common/monaco/searchdsl/completionProvider.test.ts
@@ -1017,14 +1017,14 @@ describe('grammarCompletionProvider', () => {
       const textWithSlash = `GET /_cat/indices?`;
       const textWithoutSlash = `GET _cat/indices?`;
 
-      const resultWith = grammarCompletionProvider(
-        createMockModel(textWithSlash),
-        { lineNumber: 1, column: textWithSlash.length + 1 } as monaco.Position,
-      );
-      const resultWithout = grammarCompletionProvider(
-        createMockModel(textWithoutSlash),
-        { lineNumber: 1, column: textWithoutSlash.length + 1 } as monaco.Position,
-      );
+      const resultWith = grammarCompletionProvider(createMockModel(textWithSlash), {
+        lineNumber: 1,
+        column: textWithSlash.length + 1,
+      } as monaco.Position);
+      const resultWithout = grammarCompletionProvider(createMockModel(textWithoutSlash), {
+        lineNumber: 1,
+        column: textWithoutSlash.length + 1,
+      } as monaco.Position);
 
       const labelsWith = resultWith.suggestions.map(s => s.label).sort();
       const labelsWithout = resultWithout.suggestions.map(s => s.label).sort();

--- a/tests/common/monaco/searchdsl/completionProvider.test.ts
+++ b/tests/common/monaco/searchdsl/completionProvider.test.ts
@@ -872,6 +872,261 @@ describe('grammarCompletionProvider', () => {
       expect(labels).toContain('/_aliases');
     });
   });
+
+  describe('query parameter completions', () => {
+    it('should suggest all params with descriptions for _cat/indices when cursor is right after ?', () => {
+      const text = `GET _cat/indices?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('format');
+      expect(labels).toContain('h');
+      expect(labels).toContain('s');
+      expect(labels).toContain('v');
+      expect(labels).toContain('health');
+      const formatSuggestion = result.suggestions.find(s => s.label === 'format');
+      expect(formatSuggestion?.detail).toBeTruthy();
+    });
+
+    it('should not show already-typed param when cursor is after &', () => {
+      const text = `GET _cat/indices?v=true&`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('v');
+      expect(labels).toContain('format');
+      expect(labels).toContain('h');
+      expect(labels).toContain('s');
+      expect(labels).toContain('health');
+    });
+
+    it('should show only valid enum values for format param', () => {
+      const text = `GET _cat/indices?format=`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('text');
+      expect(labels).toContain('json');
+      expect(labels).toHaveLength(2);
+    });
+
+    it('should show boolean value completions when cursor is right after = on boolean param', () => {
+      const text = `GET _cat/indices?v=`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('true');
+      expect(labels).toContain('false');
+      expect(labels).not.toContain('v');
+      expect(labels).not.toContain('h');
+    });
+
+    it('should suggest all search query params for /{index}/_search?', () => {
+      const text = `GET my_index/_search?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('q');
+      expect(labels).toContain('df');
+      expect(labels).toContain('analyzer');
+      expect(labels).toContain('default_operator');
+      expect(labels).toContain('from');
+      expect(labels).toContain('size');
+      expect(labels).toContain('sort');
+      expect(labels).toContain('timeout');
+      expect(labels).toContain('terminate_after');
+      expect(labels).toContain('track_total_hits');
+      expect(labels).toContain('search_type');
+      expect(labels).toContain('request_cache');
+      expect(labels).toContain('routing');
+      expect(labels).toContain('preference');
+    });
+
+    it('should show search_type enum values for /{index}/_search?search_type=', () => {
+      const text = `GET my_index/_search?search_type=`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('query_then_fetch');
+      expect(labels).toContain('dfs_query_then_fetch');
+    });
+
+    it('should suggest all doc query params for /{index}/_doc/{id}?', () => {
+      const text = `GET my_index/_doc/123?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('routing');
+      expect(labels).toContain('preference');
+      expect(labels).toContain('realtime');
+      expect(labels).toContain('version');
+      expect(labels).toContain('_source');
+      expect(labels).toContain('refresh');
+      expect(labels).toContain('timeout');
+    });
+
+    it('should suggest all bulk query params for POST /{index}/_bulk?', () => {
+      const text = `POST my_index/_bulk?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('refresh');
+      expect(labels).toContain('routing');
+      expect(labels).toContain('timeout');
+      expect(labels).toContain('pipeline');
+    });
+
+    it('should show refresh enum values including wait_for for POST /{index}/_bulk?refresh=', () => {
+      const text = `POST my_index/_bulk?refresh=`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('true');
+      expect(labels).toContain('false');
+      expect(labels).toContain('wait_for');
+    });
+
+    it('should produce identical param suggestions for _cat/indices? with and without leading slash', () => {
+      const textWithSlash = `GET /_cat/indices?`;
+      const textWithoutSlash = `GET _cat/indices?`;
+
+      const resultWith = grammarCompletionProvider(
+        createMockModel(textWithSlash),
+        { lineNumber: 1, column: textWithSlash.length + 1 } as monaco.Position,
+      );
+      const resultWithout = grammarCompletionProvider(
+        createMockModel(textWithoutSlash),
+        { lineNumber: 1, column: textWithoutSlash.length + 1 } as monaco.Position,
+      );
+
+      const labelsWith = resultWith.suggestions.map(s => s.label).sort();
+      const labelsWithout = resultWithout.suggestions.map(s => s.label).sort();
+      expect(labelsWith).toEqual(labelsWithout);
+    });
+
+    it('should suggest all count query params for GET /{index}/_count?', () => {
+      const text = `GET my_index/_count?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('q');
+      expect(labels).toContain('df');
+      expect(labels).toContain('analyzer');
+      expect(labels).toContain('default_operator');
+      expect(labels).toContain('routing');
+    });
+
+    it('should filter suggestions by partial name and exclude already-typed params', () => {
+      const text = `GET _cat/indices?v=true&h=columns&for`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('format');
+      expect(labels).not.toContain('v');
+      expect(labels).not.toContain('h');
+    });
+
+    it('should show all valid params when cursor returns to right after ? with nothing typed', () => {
+      const text = `GET _cat/indices?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('v');
+      expect(labels).toContain('h');
+      expect(labels).toContain('s');
+      expect(labels).toContain('format');
+      expect(labels).toContain('health');
+    });
+
+    it('should not show any already-typed params when multiple params typed and cursor after &', () => {
+      const text = `GET _cat/indices?v=true&h=value&`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('v');
+      expect(labels).not.toContain('h');
+      expect(labels).toContain('health');
+      expect(labels).toContain('format');
+    });
+
+    it('should not show already-typed params when cursor is mid-typing a new param name', () => {
+      const text = `GET _cat/indices?v=true&h`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('v');
+      expect(labels).toContain('health');
+    });
+
+    it('should show value completions when cursor is after = with partial value already typed', () => {
+      const text = `GET _cat/indices?v=true&h=col`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('v');
+      expect(labels).not.toContain('h');
+    });
+
+    it('should show value completions for second param when cursor is after = on second param', () => {
+      const text = `GET _cat/indices?v=true&health=`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('green');
+      expect(labels).toContain('yellow');
+      expect(labels).toContain('red');
+      expect(labels).not.toContain('v');
+      expect(labels).not.toContain('health');
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
This pull request enhances the query parameter support and completion experience in the search DSL editor. The main improvements include adding detailed query parameter definitions to API specs, supporting context-aware query parameter value completions, and refining the completion logic to avoid suggesting already-typed parameters. These changes make the editor more intelligent and user-friendly when constructing API requests.

**API Specification Enhancements:**

* Added comprehensive `queryParams` definitions to the Search, Count, Get Document, and Bulk APIs in `apiSpec.ts`, including types, descriptions, enums, and defaults for each parameter. [[1]](diffhunk://#diff-d5a4580dc8989a2366591d95ed66af0a1bf56c4737e6fc5d1767c2045029b4b7R100-R129) [[2]](diffhunk://#diff-d5a4580dc8989a2366591d95ed66af0a1bf56c4737e6fc5d1767c2045029b4b7R157-R168) [[3]](diffhunk://#diff-d5a4580dc8989a2366591d95ed66af0a1bf56c4737e6fc5d1767c2045029b4b7R199-R216) [[4]](diffhunk://#diff-d5a4580dc8989a2366591d95ed66af0a1bf56c4737e6fc5d1767c2045029b4b7R264-R274)

**Completion Logic Improvements:**

* Updated the completion context and logic in `completionProvider.ts` to:
  - Distinguish between query parameter names and values, enabling context-aware completions for both. [[1]](diffhunk://#diff-9d6bd054252a8a6d121c98d6407cfa2b84ce37fd1e656486887b7b71aa6283b4L128-R168) [[2]](diffhunk://#diff-3fa17f3477014c2d5735f0cce741f26592383627b7693f5891e064365231d5e3L94-R99)
  - Track and avoid suggesting query parameters that have already been typed by the user.
  - Provide value suggestions for parameters with enums or boolean types when the user is entering a value. [[1]](diffhunk://#diff-9d6bd054252a8a6d121c98d6407cfa2b84ce37fd1e656486887b7b71aa6283b4L623-R678) [[2]](diffhunk://#diff-9d6bd054252a8a6d121c98d6407cfa2b84ce37fd1e656486887b7b71aa6283b4R1726-R1728)

**Path Matching & Trigger Characters:**

* Improved the path matching function in `apiSpec.ts` to better normalize and match endpoint paths, increasing robustness.
* Expanded the set of trigger characters for completions to include `?`, `&`, and `=`, making completions more responsive during query string editing.

Refs: #363 
