### PR TITLE
feat(connection): improve floating button UX with speed-dial pattern

### DIFF
--- a/src/views/connect/components/connect-list.vue
+++ b/src/views/connect/components/connect-list.vue
@@ -166,27 +166,7 @@
     </div>
   </div>
 
-  <Dialog v-model:open="showTypeSelect">
-    <DialogContent class="database-type-dialog">
-      <DialogHeader>
-        <DialogTitle>{{ $t('connection.selectDatabase') }}</DialogTitle>
-      </DialogHeader>
-      <div class="database-type-buttons">
-        <Button
-          v-for="type in databaseTypes"
-          :key="type.value"
-          variant="outline"
-          class="database-type-btn"
-          @click="selectDatabaseType(type.value)"
-        >
-          <component :is="type.icon" class="database-type-icon" />
-          {{ type.label }}
-        </Button>
-      </div>
-    </DialogContent>
-  </Dialog>
-
-  <FloatingMenu @add="showDatabaseTypeSelect" />
+  <FloatingMenu @select="selectDatabaseType" />
   <EsConnectDialog ref="esConnectDialog" />
   <DynamodbConnectDialog ref="dynamodbConnectDialog" />
   <ConnectingModal ref="connectingModal" />
@@ -202,7 +182,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -488,29 +468,10 @@ const removeConnect = (connection: Connection) => {
   });
 };
 
-const showTypeSelect = ref(false);
 const esConnectDialog = ref();
 const dynamodbConnectDialog = ref();
 
-const databaseTypes = [
-  {
-    label: 'Elasticsearch',
-    value: DatabaseType.ELASTICSEARCH,
-    icon: elasticsearch,
-  },
-  {
-    label: 'DynamoDB',
-    value: DatabaseType.DYNAMODB,
-    icon: dynamoDB,
-  },
-];
-
-const showDatabaseTypeSelect = () => {
-  showTypeSelect.value = true;
-};
-
 const selectDatabaseType = (type: DatabaseType) => {
-  showTypeSelect.value = false;
   if (type === DatabaseType.ELASTICSEARCH) {
     esConnectDialog.value.showMedal(null);
   } else if (type === DatabaseType.DYNAMODB) {
@@ -754,26 +715,5 @@ const selectDatabaseType = (type: DatabaseType) => {
   display: flex;
   justify-content: flex-end;
   gap: 2px;
-}
-
-.database-type-dialog {
-  max-width: 400px;
-}
-
-.database-type-buttons {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.database-type-btn {
-  width: 100%;
-  justify-content: flex-start;
-  gap: 8px;
-}
-
-.database-type-icon {
-  width: 20px;
-  height: 20px;
 }
 </style>

--- a/src/views/connect/components/dynamodb-connect-dialog.vue
+++ b/src/views/connect/components/dynamodb-connect-dialog.vue
@@ -2,7 +2,10 @@
   <Dialog :open="showModal" @update:open="handleOpenChange">
     <DialogContent class="sm:max-w-[600px]" :show-close="false">
       <DialogHeader>
-        <DialogTitle>{{ modalTitle }}</DialogTitle>
+        <DialogTitle class="flex items-center gap-2">
+          <img :src="dynamoDBIcon" class="h-5 w-5" />
+          {{ modalTitle }}
+        </DialogTitle>
         <button
           class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none"
           @click="closeModal"
@@ -159,6 +162,7 @@ import { useForm } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/zod';
 import * as z from 'zod';
 import { CustomError, MIN_LOADING_TIME } from '../../../common';
+import dynamoDBIcon from '../../../assets/svg/dynamoDB.svg';
 import { useLang } from '../../../lang';
 import { useConnectionStore } from '../../../store';
 import { DatabaseType, DynamoDBConnection } from '../../../store';

--- a/src/views/connect/components/es-connect-dialog.vue
+++ b/src/views/connect/components/es-connect-dialog.vue
@@ -2,7 +2,10 @@
   <Dialog :open="showModal" @update:open="handleOpenChange">
     <DialogContent class="sm:max-w-[600px]" :show-close="false">
       <DialogHeader>
-        <DialogTitle>{{ modalTitle }}</DialogTitle>
+        <DialogTitle class="flex items-center gap-2">
+          <img :src="elasticsearchIcon" class="h-5 w-5" />
+          {{ modalTitle }}
+        </DialogTitle>
         <button
           class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none"
           @click="closeModal"
@@ -205,6 +208,7 @@ import { useForm } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/zod';
 import * as z from 'zod';
 import { CustomError, MIN_LOADING_TIME } from '../../../common';
+import elasticsearchIcon from '../../../assets/svg/elasticsearch.svg';
 import {
   Connection,
   DatabaseType,

--- a/src/views/connect/components/floating-menu.vue
+++ b/src/views/connect/components/floating-menu.vue
@@ -1,23 +1,195 @@
 <template>
-  <Button class="floating-button" variant="default" size="icon" @click="handleAddClick">
-    <span class="i-carbon-add h-8 w-8" />
-  </Button>
+  <div
+    class="floating-menu-container"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <!-- Secondary buttons (database type options) -->
+    <Transition>
+      <div v-if="isExpanded" class="secondary-buttons">
+        <Transition v-for="(db, index) in databaseTypes" :key="db.value" name="stagger" appear>
+          <TooltipProvider :delay-duration="200">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  v-show="isExpanded"
+                  variant="default"
+                  size="icon"
+                  class="secondary-button"
+                  :style="{
+                    '--enter-delay': `${(databaseTypes.length - 1 - index) * 80}ms`,
+                    '--leave-delay': `${index * 80}ms`,
+                  }"
+                  @click="handleSelect(db.value)"
+                >
+                  <component :is="db.icon" class="h-5 w-5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                {{ db.label }}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </Transition>
+      </div>
+    </Transition>
+
+    <!-- Main FAB -->
+    <Button class="floating-button" variant="default" size="icon" @click="handleFabClick">
+      <span :class="isExpanded ? 'i-carbon-close' : 'i-carbon-add'" class="h-8 w-8" />
+    </Button>
+  </div>
 </template>
 
 <script setup lang="ts">
+import { ref, onUnmounted } from 'vue';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { DatabaseType } from '@/store';
+import elasticsearch from '../../../assets/svg/elasticsearch.svg';
+import dynamoDB from '../../../assets/svg/dynamoDB.svg';
 
-const emit = defineEmits(['add']);
-const handleAddClick = () => {
-  emit('add');
+const emit = defineEmits(['select']);
+
+const isExpanded = ref(false);
+let collapseTimeout: ReturnType<typeof setTimeout> | null = null;
+
+const databaseTypes = [
+  { value: DatabaseType.ELASTICSEARCH, icon: elasticsearch, label: 'Elasticsearch' },
+  { value: DatabaseType.DYNAMODB, icon: dynamoDB, label: 'DynamoDB' },
+];
+
+const handleMouseEnter = () => {
+  if (collapseTimeout) {
+    clearTimeout(collapseTimeout);
+    collapseTimeout = null;
+  }
+  isExpanded.value = true;
 };
+
+const handleMouseLeave = () => {
+  collapseTimeout = setTimeout(() => {
+    isExpanded.value = false;
+  }, 300);
+};
+
+const handleFabClick = () => {
+  if (isExpanded.value) {
+    isExpanded.value = false;
+    if (collapseTimeout) {
+      clearTimeout(collapseTimeout);
+      collapseTimeout = null;
+    }
+  } else {
+    isExpanded.value = true;
+  }
+};
+
+const handleSelect = (type: DatabaseType) => {
+  isExpanded.value = false;
+  emit('select', type);
+};
+
+onUnmounted(() => {
+  if (collapseTimeout) {
+    clearTimeout(collapseTimeout);
+  }
+});
 </script>
 
 <style scoped>
-.floating-button {
+.floating-menu-container {
   position: fixed;
   bottom: 40px;
   right: 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.secondary-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.secondary-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    opacity 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.secondary-button:hover {
+  transform: scale(1.1);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  background: hsl(var(--muted));
+}
+
+.secondary-button:active {
+  transform: scale(0.95);
+}
+
+/* Staggered animation for secondary buttons */
+/* Enter: bottom to top (last item first) */
+.stagger-enter-active {
+  animation: stagger-fade-in 0.25s ease-out;
+  animation-delay: var(--enter-delay);
+}
+
+/* Leave: top to bottom (first item first) */
+.stagger-leave-active {
+  animation: stagger-fade-out 0.15s ease-in;
+  animation-delay: var(--leave-delay);
+}
+
+@keyframes stagger-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.8) translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes stagger-fade-out {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.8) translateY(10px);
+  }
+}
+
+/* Container transition - duration must accommodate staggered children */
+.v-enter-active {
+  transition: opacity 0.1s ease;
+}
+
+.v-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+
+.floating-button {
   width: 50px;
   height: 50px;
   border-radius: 50%;
@@ -32,11 +204,11 @@ const handleAddClick = () => {
 }
 
 .floating-button:hover {
-  transform: scale(1.1) rotate(90deg);
+  transform: scale(1.1);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
 }
 
 .floating-button:active {
-  transform: scale(0.95) rotate(90deg);
+  transform: scale(0.95);
 }
 </style>


### PR DESCRIPTION
- Replace intermediate modal with hover-expanded database type buttons
- Add staggered animations: bottom-to-top entrance, top-to-bottom exit
- Support click-to-toggle with icon switching (add/close)
- Add tooltips showing database names on hover
- Add database logos to connection dialog titles (Elasticsearch/DynamoDB) Streamlines connection creation flow: hover FAB → select database → open dialog instead of previous: click FAB → select modal → click type → open dialog
