### PR TITLE
fix: Console queries not executing after navigating to Import/Export tab

### DIFF
--- a/src/components/RouterMain.vue
+++ b/src/components/RouterMain.vue
@@ -1,11 +1,22 @@
 <template>
   <router-view v-slot="{ Component }">
-    <keep-alive>
-      <component :is="Component" v-if="route.meta.keepAlive" />
+    <keep-alive :include="keepAliveIncludes">
+      <component :is="Component" :key="route.name" />
     </keep-alive>
-    <component :is="Component" v-if="!route.meta.keepAlive" />
   </router-view>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
 const route = useRoute();
+const router = useRouter();
+
+const keepAliveIncludes = computed(() =>
+  router
+    .getRoutes()
+    .filter(r => r.meta.keepAlive)
+    .map(r => r.name as string)
+    .filter(Boolean),
+);
 </script>

--- a/src/components/tool-bar.vue
+++ b/src/components/tool-bar.vue
@@ -268,6 +268,7 @@
 <script setup lang="ts">
 import { platform } from '@tauri-apps/plugin-os';
 import { storeToRefs } from 'pinia';
+import { Loader2 } from 'lucide-vue-next';
 import {
   useClusterManageStore,
   useConnectionStore,

--- a/src/components/ui/alert-dialog/AlertDialogContent.vue
+++ b/src/components/ui/alert-dialog/AlertDialogContent.vue
@@ -2,6 +2,7 @@
 import { type HTMLAttributes, computed } from 'vue';
 import {
   AlertDialogContent,
+  AlertDialogDescription,
   type AlertDialogContentEmits,
   type AlertDialogContentProps,
   AlertDialogOverlay,
@@ -43,6 +44,9 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
       "
     >
       <slot />
+
+      <!-- Visually hidden description for accessibility (radix-vue requirement) -->
+      <AlertDialogDescription class="sr-only">Alert dialog content</AlertDialogDescription>
     </AlertDialogContent>
   </AlertDialogPortal>
 </template>

--- a/src/components/ui/dialog/DialogContent.vue
+++ b/src/components/ui/dialog/DialogContent.vue
@@ -3,6 +3,7 @@ import { type HTMLAttributes, computed } from 'vue';
 import {
   DialogClose,
   DialogContent,
+  DialogDescription,
   type DialogContentEmits,
   type DialogContentProps,
   DialogOverlay,
@@ -47,6 +48,9 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
       "
     >
       <slot />
+
+      <!-- Visually hidden description for accessibility (radix-vue requirement) -->
+      <DialogDescription class="sr-only">Dialog content</DialogDescription>
 
       <DialogClose v-if="showClose" class="dialog-close-button">
         <X class="w-4 h-4" />

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -28,7 +28,7 @@ const router = createRouter({
           name: 'Connect',
           path: '/connect/:filePath?',
           meta: {
-            keepAlive: false,
+            keepAlive: true,
           },
           component: () => import('../views/connect/index.vue'),
         },


### PR DESCRIPTION
## Summary

Fixes #381 - Console queries stop executing and response panel disappears after navigating to Import/Export tab and returning to Console.

## Root Cause Analysis

The bug was caused by a broken `keep-alive` pattern in `RouterMain.vue` that had existed since the initial implementation but was dormant until a route had `keepAlive: true`.

### Original broken pattern:
```vue
<keep-alive>
  <component :is="Component" v-if="route.meta.keepAlive" />
</keep-alive>
<component :is="Component" v-if="!route.meta.keepAlive" />
```

This pattern has two sibling `<component>` elements inside/outside `<keep-alive>`. When navigating from a route with `keepAlive: true` (ImportExport, set in commit 74a8b10), Vue Router called `deactivate()` on a parent component that didn't have this method, causing:
- `TypeError: parentComponent.ctx.deactivate is not a function`
- State corruption in the Console/Editor components

### History:
- `5c4cdb9` (Oct 2024): Router created with all routes `keepAlive: false` (default, not intentional for Connect)
- `74a8b10` (Feb 2025): ImportExport changed to `keepAlive: true` — this triggered the dormant bug
- `90f2d1d` (initial): RouterMain.vue created with broken dual-component pattern

## Fix

### 1. RouterMain.vue
```vue
<keep-alive :include="keepAliveIncludes">
  <component :is="Component" :key="route.name" />
</keep-alive>
```

- Single `<component>` always rendered through `<keep-alive>`
- `:include` filter caches only routes with `keepAlive: true` in meta
- Routes with `keepAlive: false` pass through without caching — identical behavior to before

### 2. router/index.ts
- Connect route: `keepAlive: true` — editor state persists across navigation, fixing #381

## Test Plan

- [x] Open Console, execute a query (e.g., `GET /`), verify response panel shows
- [x] Navigate to Import/Export tab
- [x] Navigate back to Console tab
- [x] Execute another query — verify it executes and response panel displays correctly
- [x] Navigate to other tabs (History, Setting, File) and back — verify no errors
- [x] Open Import/Export, start an import/export workflow, navigate away and back — verify state preserved (keepAlive behavior)

## Notes

The `keepAlive: false` on Connect was not intentional design — it was a default copied from all routes. No explicit reasoning exists in commit history. The Editor state should persist across navigation (same pattern already applied to ImportExport).