### PR TITLE
feat: unify searchable select component across codebase

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -82,6 +82,7 @@ declare module 'vue' {
     RouterView: typeof import('vue-router')['RouterView']
     ScrollArea: typeof import('./src/components/ui/scroll-area/ScrollArea.vue')['default']
     ScrollBar: typeof import('./src/components/ui/scroll-area/ScrollBar.vue')['default']
+    SearchableSelect: typeof import('./src/components/ui/combobox/SearchableSelect.vue')['default']
     Select: typeof import('./src/components/ui/select/Select.vue')['default']
     SelectContent: typeof import('./src/components/ui/select/SelectContent.vue')['default']
     SelectGroup: typeof import('./src/components/ui/select/SelectGroup.vue')['default']

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default [
       'coverage',
       '*.d.ts',
       '.vite',
+      '.claude',
     ],
   },
 

--- a/src/components/tool-bar.vue
+++ b/src/components/tool-bar.vue
@@ -1,121 +1,57 @@
 <template>
   <div class="tool-bar-container">
-    <Select
-      :model-value="connectionSelectValue"
-      @update:model-value="value => handleUpdate(value as string, 'CONNECTION')"
-      @update:open="isOpen => handleOpen(isOpen, 'CONNECTION')"
-    >
-      <SelectTrigger class="connection-select">
-        <input
-          v-if="selectionState.connection"
-          ref="connectionSearchInput"
-          v-model="filterRef.connection"
-          class="select-trigger-input"
-          autocomplete="off"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          :placeholder="connectionSelectValue || $t('connection.selectConnection')"
-          @click.stop
-        />
-        <span v-else-if="connectionSelectValue" class="select-value-text">
-          {{ connectionSelectValue }}
-        </span>
-        <span v-else class="select-placeholder-text">{{ $t('connection.selectConnection') }}</span>
-        <SelectValue class="sr-only" :placeholder="$t('connection.selectConnection')" />
-        <template #icon>
-          <span v-if="selectionState.connection" class="i-carbon-search h-4 w-4 opacity-50" />
-          <span v-else class="i-carbon-chevron-down h-4 w-4 opacity-50" />
-        </template>
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem v-for="option in options.connection" :key="option.value" :value="option.value">
-          {{ option.label }}
-        </SelectItem>
-        <div v-if="loadingRef.connection" class="select-loading">Loading...</div>
-      </SelectContent>
-    </Select>
+    <SearchableSelect
+      :model-value="connectionSelectValue || ''"
+      :options="connectionOptions"
+      :loading="loadingRef.connection"
+      :placeholder="$t('connection.selectConnection')"
+      variant="ghost"
+      :search-threshold="0"
+      class="connection-select"
+      @update:model-value="value => handleUpdate(value, 'CONNECTION')"
+      @open="isOpen => handleOpen(isOpen, 'CONNECTION')"
+    />
 
-    <Select
+    <SearchableSelect
       v-if="
         props.type === 'DYNAMO_EDITOR' || (props.type === 'MANAGE' && !isElasticsearchConnection)
       "
-      :model-value="tableSelectValue"
-      @update:model-value="value => handleUpdate(value as string, 'TABLE')"
-      @update:open="isOpen => handleOpen(isOpen, 'TABLE')"
+      :model-value="tableSelectValue || ''"
+      :options="tableOptions"
+      :loading="loadingRef.table"
+      :placeholder="$t('connection.selectTable')"
+      variant="ghost"
+      :search-threshold="0"
+      class="index-select"
+      @update:model-value="value => handleUpdate(value, 'TABLE')"
+      @open="isOpen => handleOpen(isOpen, 'TABLE')"
     >
-      <SelectTrigger class="index-select">
-        <input
-          v-if="selectionState.table"
-          ref="tableSearchInput"
-          v-model="filterRef.table"
-          class="select-trigger-input"
-          autocomplete="off"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          :placeholder="tableSelectValue || $t('connection.selectTable')"
-          @click.stop
-        />
-        <span v-else-if="tableSelectValue" class="select-value-text">{{ tableSelectValue }}</span>
-        <span v-else class="select-placeholder-text">{{ $t('connection.selectTable') }}</span>
-        <SelectValue class="sr-only" :placeholder="$t('connection.selectTable')" />
-        <template #icon>
-          <span v-if="selectionState.table" class="i-carbon-search h-4 w-4 opacity-50" />
-          <span v-else class="i-carbon-chevron-down h-4 w-4 opacity-50" />
-        </template>
-      </SelectTrigger>
-      <SelectContent>
-        <div v-if="loadingRef.table" class="select-loading">Loading...</div>
-        <SelectItem v-for="opt in options.table" v-else :key="opt.value" :value="opt.value">
-          <span class="flex items-center gap-1 w-full">
-            <span
-              class="h-3.5 w-3.5 shrink-0 cursor-pointer"
-              :class="
-                opt.favorite ? 'i-carbon-star-filled text-yellow-400' : 'i-carbon-star opacity-40'
-              "
-              @click.stop="toggleFavoriteTable(opt.value)"
-            />
-            {{ opt.label }}
-          </span>
-        </SelectItem>
-      </SelectContent>
-    </Select>
-
-    <Select
-      v-if="props.type === 'ES_EDITOR'"
-      :model-value="indexSelectValue"
-      @update:model-value="value => handleUpdate(value as string, 'INDEX')"
-      @update:open="isOpen => handleOpen(isOpen, 'INDEX')"
-    >
-      <SelectTrigger class="index-select">
-        <input
-          v-if="selectionState.index"
-          ref="indexSearchInput"
-          v-model="filterRef.index"
-          class="select-trigger-input"
-          autocomplete="off"
-          autocorrect="off"
-          autocapitalize="off"
-          spellcheck="false"
-          :placeholder="indexSelectValue || $t('connection.selectIndex')"
-          @click.stop
-        />
-        <span v-else-if="indexSelectValue" class="select-value-text">{{ indexSelectValue }}</span>
-        <span v-else class="select-placeholder-text">{{ $t('connection.selectIndex') }}</span>
-        <SelectValue class="sr-only" :placeholder="$t('connection.selectIndex')" />
-        <template #icon>
-          <span v-if="selectionState.index" class="i-carbon-search h-4 w-4 opacity-50" />
-          <span v-else class="i-carbon-chevron-down h-4 w-4 opacity-50" />
-        </template>
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem v-for="option in options.index" :key="option.value" :value="option.value">
+      <template #option="{ option }">
+        <span class="flex items-center gap-1 w-full">
+          <span
+            class="h-3.5 w-3.5 shrink-0 cursor-pointer"
+            :class="
+              option.favorite ? 'i-carbon-star-filled text-yellow-400' : 'i-carbon-star opacity-40'
+            "
+            @click.stop="toggleFavoriteTable(option.value)"
+          />
           {{ option.label }}
-        </SelectItem>
-        <div v-if="loadingRef.index" class="select-loading">Loading...</div>
-      </SelectContent>
-    </Select>
+        </span>
+      </template>
+    </SearchableSelect>
+
+    <SearchableSelect
+      v-if="props.type === 'ES_EDITOR'"
+      :model-value="indexSelectValue || ''"
+      :options="indexOptions"
+      :loading="loadingRef.index"
+      :placeholder="$t('connection.selectIndex')"
+      variant="ghost"
+      :search-threshold="0"
+      class="index-select"
+      @update:model-value="value => handleUpdate(value, 'INDEX')"
+      @open="isOpen => handleOpen(isOpen, 'INDEX')"
+    />
 
     <TooltipProvider
       v-if="props.type === 'ES_EDITOR' || (props.type === 'MANAGE' && isElasticsearchConnection)"
@@ -282,13 +218,7 @@ import { CustomError } from '../common';
 import { esSampleQueries } from '../common/monaco';
 import { useMessageService } from '@/composables';
 import { Button } from '@/components/ui/button';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { SearchableSelect } from '@/components/ui/combobox';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 const props = defineProps({ type: { type: String, default: undefined } });
@@ -325,17 +255,6 @@ const showRunButton = computed(() => {
 });
 
 const loadingRef = ref({ connection: false, index: false, table: false });
-
-const filterRef = ref({ connection: '', index: '', table: '' });
-const connectionSearchInput = ref<HTMLInputElement>();
-const indexSearchInput = ref<HTMLInputElement>();
-const tableSearchInput = ref<HTMLInputElement>();
-
-const selectionState = ref<{ connection: boolean; index: boolean; table: boolean }>({
-  connection: false,
-  index: false,
-  table: false,
-});
 
 const hideSystemIndicesRef = ref(true);
 const isExecuting = ref(false);
@@ -375,7 +294,18 @@ const tableSelectValue = computed(() => {
   return activePanel?.value?.activeTable;
 });
 
-const dynamoTableOptions = computed(() => {
+const connectionOptions = computed(() =>
+  connections.value.map(({ name }) => ({ label: name, value: name })),
+);
+
+const indexOptions = computed(
+  () =>
+    activeElasticsearchIndexOption.value?.filter(index =>
+      hideSystemIndicesRef.value ? !index.value.startsWith('.') : true,
+    ) ?? [],
+);
+
+const tableOptions = computed(() => {
   const conn = (
     ['ES_EDITOR', 'DYNAMO_EDITOR'].includes(props.type ?? '')
       ? activePanel.value.connection
@@ -387,11 +317,7 @@ const dynamoTableOptions = computed(() => {
   return [
     ...tables.filter(n => favorites.includes(n)),
     ...tables.filter(n => !favorites.includes(n)),
-  ]
-    .filter(
-      n => !filterRef.value.table || n.toLowerCase().includes(filterRef.value.table.toLowerCase()),
-    )
-    .map(n => ({ label: n, value: n, favorite: favorites.includes(n) }));
+  ].map(n => ({ label: n, value: n, favorite: favorites.includes(n) }));
 });
 
 const esSampleQueryOptions = computed(() => [
@@ -473,46 +399,8 @@ watch(
   { immediate: true },
 );
 
-const options = computed(
-  () =>
-    ({
-      connection: connections.value
-        .filter(
-          ({ name }) =>
-            !filterRef.value.connection ||
-            name.toLowerCase().includes(filterRef.value.connection.toLowerCase()),
-        )
-        .map(({ name }) => ({ label: name, value: name })),
-      index: activeElasticsearchIndexOption.value
-        ?.filter(index => (hideSystemIndicesRef.value ? !index.value.startsWith('.') : true))
-        .filter(
-          index =>
-            !filterRef.value.index ||
-            index.value.toLowerCase().includes(filterRef.value.index.toLowerCase()),
-        ),
-      table: dynamoTableOptions.value,
-    }) as Record<string, { label: string; value: string; favorite?: boolean }[]>,
-);
-
 const handleOpen = async (isOpen: boolean, type: 'CONNECTION' | 'INDEX' | 'TABLE') => {
-  if (!isOpen) {
-    // @ts-ignore
-    selectionState.value[type.toLowerCase()] = false;
-    return;
-  }
-  // @ts-ignore
-  selectionState.value[type.toLowerCase()] = true;
-  filterRef.value = { connection: '', index: '', table: '' };
-
-  setTimeout(() => {
-    if (type === 'CONNECTION' && connectionSearchInput.value) {
-      connectionSearchInput.value.focus();
-    } else if (type === 'INDEX' && indexSearchInput.value) {
-      indexSearchInput.value.focus();
-    } else if (type === 'TABLE' && tableSearchInput.value) {
-      tableSearchInput.value.focus();
-    }
-  }, 0);
+  if (!isOpen) return;
 
   if (type === 'CONNECTION') {
     loadingRef.value.connection = true;
@@ -668,67 +556,42 @@ const handleEditorSwitch = async (
   margin-right: 10px;
 }
 
-.connection-select {
+:deep(.connection-select) {
   margin: 0;
   padding: 0 12px;
   height: 35px;
-  max-width: 300px;
-  min-width: 200px;
+  width: 220px;
+  flex-shrink: 0;
   border: none;
   border-right: 1px solid hsl(var(--border));
   border-radius: 0;
   background: transparent;
   box-shadow: none;
+  overflow: hidden;
 }
 
-.connection-select:focus {
+:deep(.connection-select:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.index-select {
+:deep(.index-select) {
   margin: 0;
   padding: 0 12px;
   height: 35px;
-  max-width: 300px;
-  min-width: 200px;
+  width: 220px;
+  flex-shrink: 0;
   border: none;
   border-right: 1px solid hsl(var(--border));
   border-radius: 0;
   background: transparent;
   box-shadow: none;
+  overflow: hidden;
 }
 
-.index-select:focus {
+:deep(.index-select:focus-visible) {
   outline: none;
   box-shadow: none;
-}
-
-.select-search-container {
-  padding: 8px;
-  border-bottom: 1px solid hsl(var(--border));
-}
-
-.select-search-input {
-  width: 100%;
-  padding: 6px 8px;
-  border: 1px solid hsl(var(--border));
-  border-radius: 4px;
-  font-size: 14px;
-  background: hsl(var(--background));
-  color: inherit;
-}
-
-.select-search-input:focus {
-  outline: none;
-  border-color: hsl(var(--primary));
-}
-
-.select-loading {
-  padding: 8px;
-  text-align: center;
-  color: hsl(var(--muted-foreground));
-  font-size: 12px;
 }
 
 .button-group {
@@ -755,47 +618,10 @@ const handleEditorSwitch = async (
   margin-right: 4px;
 }
 
-.select-value-text {
-  flex: 1;
-  text-align: left;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.select-search-container {
+  padding: 8px;
+  border-bottom: 1px solid hsl(var(--border));
 }
-
-.select-trigger-input {
-  flex: 1;
-  border: none;
-  outline: none;
-  background: transparent;
-  color: inherit;
-  font-size: 14px;
-  padding: 0;
-  width: 100%;
-}
-
-.select-trigger-input::placeholder {
-  color: hsl(var(--muted-foreground));
-}
-
-.select-placeholder-text {
-  flex: 1;
-  text-align: left;
-  color: hsl(var(--muted-foreground));
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
 .help-button-container {
   margin-right: 10px;
   display: flex;

--- a/src/components/tool-bar.vue
+++ b/src/components/tool-bar.vue
@@ -618,10 +618,6 @@ const handleEditorSwitch = async (
   margin-right: 4px;
 }
 
-.select-search-container {
-  padding: 8px;
-  border-bottom: 1px solid hsl(var(--border));
-}
 .help-button-container {
   margin-right: 10px;
   display: flex;

--- a/src/components/tool-bar.vue
+++ b/src/components/tool-bar.vue
@@ -295,14 +295,16 @@ const tableSelectValue = computed(() => {
 });
 
 const connectionOptions = computed(() =>
-  connections.value.map(({ name }) => ({ label: name, value: name })),
+  connections.value
+    .map(({ name }) => ({ label: name, value: name }))
+    .sort((a, b) => a.label.localeCompare(b.label)),
 );
 
 const indexOptions = computed(
   () =>
-    activeElasticsearchIndexOption.value?.filter(index =>
-      hideSystemIndicesRef.value ? !index.value.startsWith('.') : true,
-    ) ?? [],
+    activeElasticsearchIndexOption.value
+      ?.filter(index => (hideSystemIndicesRef.value ? !index.value.startsWith('.') : true))
+      ?.sort((a, b) => a.label.localeCompare(b.label)) ?? [],
 );
 
 const tableOptions = computed(() => {
@@ -314,10 +316,17 @@ const tableOptions = computed(() => {
   if (!conn || conn.type !== DatabaseType.DYNAMODB) return [];
   const favorites = conn.favoriteTables ?? [];
   const tables = (conn.tables ?? []).map(t => t.name);
-  return [
-    ...tables.filter(n => favorites.includes(n)),
-    ...tables.filter(n => !favorites.includes(n)),
-  ].map(n => ({ label: n, value: n, favorite: favorites.includes(n) }));
+  const favoriteTables = tables
+    .filter(n => favorites.includes(n))
+    .sort((a, b) => a.localeCompare(b));
+  const nonFavoriteTables = tables
+    .filter(n => !favorites.includes(n))
+    .sort((a, b) => a.localeCompare(b));
+  return [...favoriteTables, ...nonFavoriteTables].map(n => ({
+    label: n,
+    value: n,
+    favorite: favorites.includes(n),
+  }));
 });
 
 const esSampleQueryOptions = computed(() => [

--- a/src/components/ui/combobox/SearchableSelect.vue
+++ b/src/components/ui/combobox/SearchableSelect.vue
@@ -65,6 +65,12 @@ const filteredOptions = computed(() => {
   );
 });
 
+const showCreateNew = computed(() => {
+  const trimmed = searchQuery.value.trim();
+  if (!props.allowCreate || !trimmed) return false;
+  return !props.options.some(opt => opt.value === trimmed || opt.label === trimmed);
+});
+
 const selectOption = (value: string) => {
   emits('update:modelValue', value);
   open.value = false;
@@ -130,7 +136,7 @@ watch(open, async isOpen => {
         </div>
 
         <div
-          v-if="filteredOptions.length === 0 && searchQuery && !allowCreate"
+          v-if="filteredOptions.length === 0 && searchQuery && !showCreateNew && !loading"
           class="flex flex-col items-center gap-2 px-2 py-8 text-center text-sm text-muted-foreground"
         >
           <span class="i-carbon-search h-5 w-5 opacity-40" />
@@ -138,12 +144,12 @@ watch(open, async isOpen => {
         </div>
 
         <div
-          v-if="allowCreate && searchQuery && !filteredOptions.length"
+          v-if="showCreateNew"
           class="relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none text-[#18a058] italic hover:bg-accent"
-          @click="selectOption(searchQuery)"
+          @click="selectOption(searchQuery.trim())"
         >
           <span class="i-carbon-add h-4 w-4" />
-          {{ createText }}: "{{ searchQuery }}"
+          {{ createText }}: "{{ searchQuery.trim() }}"
         </div>
       </div>
 

--- a/src/components/ui/combobox/SearchableSelect.vue
+++ b/src/components/ui/combobox/SearchableSelect.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import { nextTick } from 'vue';
+import type { ComboboxOption } from './types';
+import { cn } from '@/lib/utils';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+
+const props = withDefaults(
+  defineProps<{
+    options: ComboboxOption[];
+    modelValue: string;
+    placeholder?: string;
+    searchPlaceholder?: string;
+    disabled?: boolean;
+    loading?: boolean;
+    emptyText?: string;
+    allowCreate?: boolean;
+    createText?: string;
+    searchThreshold?: number;
+    variant?: 'outline' | 'ghost';
+    class?: string;
+  }>(),
+  {
+    placeholder: 'Select...',
+    searchPlaceholder: 'Search...',
+    disabled: false,
+    loading: false,
+    emptyText: 'No results',
+    allowCreate: false,
+    createText: 'Create',
+    searchThreshold: 10,
+    variant: 'outline',
+    class: undefined,
+  },
+);
+
+const emits = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+  (e: 'open', isOpen: boolean): void;
+}>();
+
+const open = ref(false);
+const searchQuery = ref('');
+const searchInputRef = ref<HTMLInputElement>();
+
+const showSearch = computed(
+  () => props.options.length > props.searchThreshold || props.allowCreate,
+);
+
+const selectedLabel = computed(() => {
+  const found = props.options.find(opt => opt.value === props.modelValue);
+  if (found) return found.label;
+  if (props.allowCreate && props.modelValue) return props.modelValue;
+  return undefined;
+});
+
+const filteredOptions = computed(() => {
+  if (!searchQuery.value.trim()) {
+    return props.options;
+  }
+  const query = searchQuery.value.toLowerCase();
+  return props.options.filter(
+    opt => opt.label.toLowerCase().includes(query) || opt.value.toLowerCase().includes(query),
+  );
+});
+
+const selectOption = (value: string) => {
+  emits('update:modelValue', value);
+  open.value = false;
+};
+
+watch(open, async isOpen => {
+  if (!isOpen) {
+    searchQuery.value = '';
+  } else if (showSearch.value) {
+    await nextTick();
+    searchInputRef.value?.focus();
+  }
+  emits('open', isOpen);
+});
+</script>
+
+<template>
+  <Popover v-model:open="open">
+    <PopoverTrigger as-child>
+      <Button
+        :variant="variant"
+        role="combobox"
+        :disabled="disabled"
+        :class="cn('justify-between font-normal', props.class)"
+      >
+        <template v-if="open && showSearch">
+          <input
+            ref="searchInputRef"
+            v-model="searchQuery"
+            :placeholder="searchPlaceholder || placeholder"
+            class="flex-1 border-0 outline-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground"
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            @click.stop
+            @keydown.escape="open = false"
+          />
+          <span class="i-carbon-search h-4 w-4 ml-2 shrink-0 opacity-50" />
+        </template>
+        <template v-else>
+          <span v-if="selectedLabel" class="truncate">{{ selectedLabel }}</span>
+          <span v-else class="text-muted-foreground truncate">{{ placeholder }}</span>
+          <span class="i-carbon-chevron-down h-4 w-4 ml-2 shrink-0 opacity-50" />
+        </template>
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent :align="'start'" class="w-[--radix-popover-trigger-width] p-1">
+      <div class="max-h-[280px] overflow-y-auto p-1">
+        <div
+          v-for="option in filteredOptions"
+          :key="option.value"
+          :class="[
+            'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+            option.disabled && 'pointer-events-none opacity-50',
+            option.value === modelValue && 'bg-accent text-accent-foreground',
+          ]"
+          @click="!option.disabled && selectOption(option.value)"
+        >
+          <slot name="option" :option="option">
+            {{ option.label }}
+          </slot>
+        </div>
+
+        <div
+          v-if="filteredOptions.length === 0 && searchQuery && !allowCreate"
+          class="flex flex-col items-center gap-2 px-2 py-8 text-center text-sm text-muted-foreground"
+        >
+          <span class="i-carbon-search h-5 w-5 opacity-40" />
+          <span>No results for "{{ searchQuery }}"</span>
+        </div>
+
+        <div
+          v-if="allowCreate && searchQuery && !filteredOptions.length"
+          class="relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none text-[#18a058] italic hover:bg-accent"
+          @click="selectOption(searchQuery)"
+        >
+          <span class="i-carbon-add h-4 w-4" />
+          {{ createText }}: "{{ searchQuery }}"
+        </div>
+      </div>
+
+      <div
+        v-if="filteredOptions.length === 0 && !searchQuery && !loading"
+        class="flex flex-col items-center gap-2 px-2 py-8 text-center text-sm text-muted-foreground"
+      >
+        <span class="i-carbon-incomplete h-5 w-5 opacity-40" />
+        {{ emptyText }}
+      </div>
+
+      <div
+        v-if="loading"
+        class="flex items-center justify-center py-4 gap-2 text-sm text-muted-foreground"
+      >
+        <Spinner class="h-4 w-4" />
+        Loading...
+      </div>
+    </PopoverContent>
+  </Popover>
+</template>

--- a/src/components/ui/combobox/index.ts
+++ b/src/components/ui/combobox/index.ts
@@ -1,0 +1,2 @@
+export { default as SearchableSelect } from './SearchableSelect.vue';
+export type { ComboboxOption } from './types';

--- a/src/components/ui/combobox/types.ts
+++ b/src/components/ui/combobox/types.ts
@@ -1,0 +1,5 @@
+export type ComboboxOption = {
+  label: string;
+  value: string;
+  disabled?: boolean;
+};

--- a/src/components/ui/combobox/types.ts
+++ b/src/components/ui/combobox/types.ts
@@ -2,4 +2,5 @@ export type ComboboxOption = {
   label: string;
   value: string;
   disabled?: boolean;
+  favorite?: boolean;
 };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -22,6 +22,7 @@ export * from './input-number';
 export * from './select';
 export * from './switch';
 export * from './radio-group';
+export * from './combobox';
 
 // Layout Components
 export * from './grid';

--- a/src/views/connect/components/dynamodb-connect-dialog.vue
+++ b/src/views/connect/components/dynamodb-connect-dialog.vue
@@ -81,23 +81,12 @@
                 required
                 :error="getError('region', errors.region)"
               >
-                <Select
+                <SearchableSelect
                   v-model="formData.region"
-                  @update:open="(open: boolean) => !open && handleBlur('region')"
-                >
-                  <SelectTrigger>
-                    <SelectValue :placeholder="$t('connection.selectRegion')" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem
-                      v-for="option in regionOptions"
-                      :key="option.value"
-                      :value="option.value"
-                    >
-                      {{ option.label }}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+                  :options="regionOptions"
+                  :placeholder="$t('connection.selectRegion')"
+                  @update:model-value="handleBlur('region')"
+                />
               </FormItem>
 
               <!-- Access Key fields -->
@@ -316,6 +305,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { SearchableSelect } from '@/components/ui/combobox';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Badge } from '@/components/ui/badge';
 

--- a/src/views/editor/dynamo-editor/components/ui-editor.vue
+++ b/src/views/editor/dynamo-editor/components/ui-editor.vue
@@ -8,56 +8,35 @@
             <Grid :cols="24" :x-gap="12">
               <GridItem :span="8">
                 <FormItem :label="$t('editor.dynamo.selectIndex')">
-                  <Select
-                    :model-value="dynamoQueryForm.index ?? undefined"
-                    :disabled="indexSelectDisabled"
-                    @update:open="handleIndexOpen"
+                  <TooltipProvider v-if="indexSelectDisabled">
+                    <Tooltip>
+                      <TooltipTrigger as-child>
+                        <span class="inline-flex w-full">
+                          <SearchableSelect
+                            :model-value="dynamoQueryForm.index ?? ''"
+                            :options="indicesOrTableOptions"
+                            :loading="loadingRef.index"
+                            :placeholder="$t('editor.dynamo.selectIndex')"
+                            disabled
+                            class="w-full"
+                          />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {{ $t('editor.dynamo.selectTableFirst') }}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                  <SearchableSelect
+                    v-else
+                    :model-value="dynamoQueryForm.index ?? ''"
+                    :options="indicesOrTableOptions"
+                    :loading="loadingRef.index"
+                    :placeholder="$t('editor.dynamo.selectIndex')"
+                    class="w-full"
                     @update:model-value="handleSelectUpdate"
-                  >
-                    <TooltipProvider v-if="indexSelectDisabled">
-                      <Tooltip>
-                        <TooltipTrigger as-child>
-                          <span class="inline-flex w-full">
-                            <SelectTrigger>
-                              <span
-                                v-if="dynamoQueryForm.index && selectedIndexOrTable"
-                                class="select-value-text"
-                              >
-                                {{ selectedIndexOrTable.label }}
-                              </span>
-                              <SelectValue v-else :placeholder="$t('editor.dynamo.selectIndex')" />
-                            </SelectTrigger>
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          {{ $t('editor.dynamo.selectTableFirst') }}
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                    <SelectTrigger v-else>
-                      <span
-                        v-if="dynamoQueryForm.index && selectedIndexOrTable"
-                        class="select-value-text"
-                      >
-                        {{ selectedIndexOrTable.label }}
-                      </span>
-                      <SelectValue v-else :placeholder="$t('editor.dynamo.selectIndex')" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <div v-if="loadingRef.index" class="flex items-center justify-center py-4">
-                        <Spinner class="h-4 w-4 mr-2" />
-                        <span class="text-sm text-muted-foreground">Loading...</span>
-                      </div>
-                      <SelectItem
-                        v-for="option in indicesOrTableOptions"
-                        v-else
-                        :key="option.value"
-                        :value="option.value"
-                      >
-                        {{ option.label }}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
+                    @open="isOpen => isOpen && handleIndexOpen(true)"
+                  />
                 </FormItem>
               </GridItem>
 
@@ -217,6 +196,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { SearchableSelect } from '@/components/ui/combobox';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';

--- a/src/views/import-export/components/export-source-scope.vue
+++ b/src/views/import-export/components/export-source-scope.vue
@@ -34,6 +34,7 @@
             :model-value="inputData.selectedIndex"
             :options="indexOptions"
             :loading="loadingStat.index"
+            :search-threshold="0"
             :disabled="
               !inputData.selectedConnection || loadingStat.connection || loadingStat.connecting
             "

--- a/src/views/import-export/components/export-source-scope.vue
+++ b/src/views/import-export/components/export-source-scope.vue
@@ -18,62 +18,30 @@
       <Grid :cols="2" :x-gap="16" :y-gap="16">
         <GridItem>
           <div class="field-label">{{ $t('export.sourceDatabase') }}</div>
-          <Select
-            v-model="inputData.selectedConnection"
+          <SearchableSelect
+            :model-value="inputData.selectedConnection"
+            :options="connectionOptions"
+            :loading="loadingStat.connection"
+            :placeholder="$t('connection.selectConnection')"
+            class="w-full"
             @update:model-value="handleConnectionChange"
-            @update:open="handleConnectionOpen"
-          >
-            <SelectTrigger class="w-full">
-              <SelectValue :placeholder="$t('connection.selectConnection')" />
-            </SelectTrigger>
-            <SelectContent>
-              <div v-if="loadingStat.connection" class="flex items-center justify-center py-4">
-                <Spinner class="h-4 w-4" />
-              </div>
-              <template v-else>
-                <SelectItem
-                  v-for="option in filteredConnectionOptions"
-                  :key="option.value"
-                  :value="option.value"
-                >
-                  {{ option.label }}
-                </SelectItem>
-              </template>
-            </SelectContent>
-          </Select>
+            @open="isOpen => isOpen && handleConnectionOpen(true)"
+          />
         </GridItem>
         <GridItem>
           <div class="field-label">{{ $t('export.collectionName') }}</div>
-          <Select
-            v-model="inputData.selectedIndex"
+          <SearchableSelect
+            :model-value="inputData.selectedIndex"
+            :options="indexOptions"
+            :loading="loadingStat.index"
             :disabled="
               !inputData.selectedConnection || loadingStat.connection || loadingStat.connecting
             "
+            :placeholder="$t('connection.selectIndex')"
+            class="w-full"
             @update:model-value="handleIndexChange"
-            @update:open="handleIndexOpen"
-          >
-            <SelectTrigger class="w-full">
-              <div v-if="loadingStat.index" class="flex items-center gap-2">
-                <Spinner class="h-3 w-3" />
-                <span class="text-muted-foreground text-sm">{{ $t('export.loadingIndices') }}</span>
-              </div>
-              <SelectValue v-else :placeholder="$t('connection.selectIndex')" />
-            </SelectTrigger>
-            <SelectContent>
-              <div v-if="loadingStat.index" class="flex items-center justify-center py-4">
-                <Spinner class="h-4 w-4" />
-              </div>
-              <template v-else>
-                <SelectItem
-                  v-for="option in filteredIndexOptions"
-                  :key="option.value"
-                  :value="option.value"
-                >
-                  {{ option.label }}
-                </SelectItem>
-              </template>
-            </SelectContent>
-          </Select>
+            @open="isOpen => isOpen && handleIndexOpen(true)"
+          />
         </GridItem>
       </Grid>
 
@@ -95,15 +63,9 @@
 <script setup lang="ts">
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Grid, GridItem } from '@/components/ui/grid';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
 import { Collapse, CollapseItem } from '@/components/ui/collapse';
 import { Spinner } from '@/components/ui/spinner';
+import { SearchableSelect } from '@/components/ui/combobox';
 import { CustomError } from '../../../common';
 import { useLang } from '../../../lang';
 import {
@@ -130,8 +92,6 @@ const { connection, selectedIndex, filterQuery } = storeToRefs(exportStore);
 const inputData = ref({
   selectedConnection: '',
   selectedIndex: '',
-  connectionSearchQuery: '',
-  indexSearchQuery: '',
 });
 const loadingStat = ref({
   connection: false,
@@ -151,40 +111,7 @@ const connectionOptions = computed(() =>
   connections.value.map(({ name }) => ({ label: name, value: name })),
 );
 
-const filteredConnectionOptions = computed(() => {
-  if (!inputData.value.connectionSearchQuery) {
-    return connectionOptions.value;
-  }
-  const query = inputData.value.connectionSearchQuery.toLowerCase();
-  return connectionOptions.value
-    .filter(option => option.value.toLowerCase().includes(query))
-    .sort((a, b) => a.value.localeCompare(b.value));
-});
-
 const indexOptions = ref<Array<{ label: string; value: string }>>([]);
-
-const filteredIndexOptions = computed(() => {
-  if (!inputData.value.indexSearchQuery) {
-    return indexOptions.value;
-  }
-  const query = inputData.value.indexSearchQuery.toLowerCase();
-  return indexOptions.value
-    .filter(option => option.value.toLowerCase().includes(query))
-    .sort((a, b) => a.value.localeCompare(b.value));
-});
-
-const handleConnectionSearch = (query: string) => {
-  inputData.value.connectionSearchQuery = query;
-};
-
-const handleIndexSearch = (query: string) => {
-  inputData.value.indexSearchQuery = query;
-};
-
-// Note: handleConnectionSearch and handleIndexSearch are kept for future use
-// if search functionality is re-added to the Select component
-void handleConnectionSearch;
-void handleIndexSearch;
 
 const handleConnectionOpen = async (isOpen: boolean) => {
   if (!isOpen) return;

--- a/src/views/import-export/components/export-source-scope.vue
+++ b/src/views/import-export/components/export-source-scope.vue
@@ -22,6 +22,7 @@
             :model-value="inputData.selectedConnection"
             :options="connectionOptions"
             :loading="loadingStat.connection"
+            :search-threshold="0"
             :placeholder="$t('connection.selectConnection')"
             class="w-full"
             @update:model-value="handleConnectionChange"
@@ -109,7 +110,9 @@ const selectionSummary = computed(() => {
 });
 
 const connectionOptions = computed(() =>
-  connections.value.map(({ name }) => ({ label: name, value: name })),
+  connections.value
+    .map(({ name }) => ({ label: name, value: name }))
+    .sort((a, b) => a.label.localeCompare(b.label)),
 );
 
 const indexOptions = ref<Array<{ label: string; value: string }>>([]);
@@ -151,15 +154,17 @@ const handleIndexOpen = async (isOpen: boolean) => {
       await fetchIndices(connection.value);
       const updatedCon =
         connections.value.find(c => c.id === connection.value?.id) ?? connection.value;
-      indexOptions.value =
-        (updatedCon as ElasticsearchConnection)?.indices?.map(index => ({
-          label: index.index,
-          value: index.index,
-        })) ?? [];
+      const indices = (updatedCon as ElasticsearchConnection)?.indices ?? [];
+      indexOptions.value = indices
+        .map(index => ({ label: index.index, value: index.index }))
+        .sort((a, b) => a.label.localeCompare(b.label));
     } else if (connection.value.type === DatabaseType.DYNAMODB) {
       // DynamoDB metadata is already populated by freshConnection — no extra fetch needed.
       const dynamoConn = connection.value as DynamoDBConnection;
-      indexOptions.value = dynamoConn.tables?.map(t => ({ label: t.name, value: t.name })) ?? [];
+      indexOptions.value =
+        dynamoConn.tables
+          ?.map(t => ({ label: t.name, value: t.name }))
+          .sort((a, b) => a.label.localeCompare(b.label)) ?? [];
     }
   } catch (err) {
     const error = err as CustomError;

--- a/src/views/import-export/components/export-source-scope.vue
+++ b/src/views/import-export/components/export-source-scope.vue
@@ -183,7 +183,6 @@ const handleConnectionChange = async (value: string) => {
     inputData.value.selectedConnection = value;
     inputData.value.selectedIndex = '';
     indexOptions.value = [];
-    inputData.value.indexSearchQuery = '';
     // Fetch indices immediately after connection change
     await handleIndexOpen(true);
   } catch (err) {

--- a/src/views/import-export/components/import-target-output.vue
+++ b/src/views/import-export/components/import-target-output.vue
@@ -15,6 +15,7 @@
             :model-value="inputData.selectedConnection"
             :options="connectionOptions"
             :loading="loadingStat.connection"
+            :search-threshold="0"
             :placeholder="$t('connection.selectConnection')"
             class="w-full"
             @update:model-value="handleConnectionChange"
@@ -103,7 +104,9 @@ const indexOptions = ref<Array<{ label: string; value: string }>>([]);
 const currentExistingIndices = ref<string[]>([]);
 
 const connectionOptions = computed(() =>
-  connections.value.map(({ name }) => ({ label: name, value: name })),
+  connections.value
+    .map(({ name }) => ({ label: name, value: name }))
+    .sort((a, b) => a.label.localeCompare(b.label)),
 );
 
 const handleConnectionOpen = async () => {
@@ -167,15 +170,16 @@ const updateIndexOptions = () => {
     const indices =
       (updatedCon as ElasticsearchConnection)?.indices?.map(index => index.index) ?? [];
     currentExistingIndices.value = indices;
-    indexOptions.value = indices.map(index => ({
-      label: index,
-      value: index,
-    }));
+    indexOptions.value = indices
+      .map(index => ({ label: index, value: index }))
+      .sort((a, b) => a.label.localeCompare(b.label));
   } else if (importConnection.value.type === DatabaseType.DYNAMODB) {
     const dynamoConn = importConnection.value as DynamoDBConnection;
     const tables = dynamoConn.tables ?? [];
     currentExistingIndices.value = tables.map(t => t.name);
-    indexOptions.value = tables.map(t => ({ label: t.name, value: t.name }));
+    indexOptions.value = tables
+      .map(t => ({ label: t.name, value: t.name }))
+      .sort((a, b) => a.label.localeCompare(b.label));
   }
 };
 

--- a/src/views/import-export/components/import-target-output.vue
+++ b/src/views/import-export/components/import-target-output.vue
@@ -190,7 +190,6 @@ const handleConnectionChange = async (value: string) => {
     inputData.value.selectedConnection = value;
     inputData.value.selectedIndex = '';
     indexOptions.value = [];
-    inputData.value.indexSearchQuery = '';
     currentExistingIndices.value = [];
     // Fetch indices after connection change
     await handleIndexOpen();

--- a/src/views/import-export/components/import-target-output.vue
+++ b/src/views/import-export/components/import-target-output.vue
@@ -11,88 +11,31 @@
       <Grid :cols="2" :x-gap="16" :y-gap="16">
         <GridItem>
           <div class="field-label">{{ $t('import.targetDatabase') }}</div>
-          <Select
-            v-model="inputData.selectedConnection"
+          <SearchableSelect
+            :model-value="inputData.selectedConnection"
+            :options="connectionOptions"
+            :loading="loadingStat.connection"
+            :placeholder="$t('connection.selectConnection')"
+            class="w-full"
             @update:model-value="handleConnectionChange"
-          >
-            <SelectTrigger>
-              <SelectValue :placeholder="$t('connection.selectConnection')" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem
-                v-for="option in filteredConnectionOptions"
-                :key="option.value"
-                :value="option.value"
-              >
-                {{ option.label }}
-              </SelectItem>
-            </SelectContent>
-          </Select>
+          />
         </GridItem>
         <GridItem>
           <div class="field-label">{{ $t('import.collectionName') }}</div>
-
-          <!-- Combobox: searchable dropdown + free-text entry -->
-          <Popover v-model:open="indexDropdownOpen">
-            <PopoverTrigger as-child>
-              <Button
-                variant="outline"
-                role="combobox"
-                :aria-expanded="indexDropdownOpen"
-                :disabled="!inputData.selectedConnection || loadingStat.connection"
-                class="combobox-trigger"
-              >
-                <span :class="inputData.selectedIndex ? 'combobox-value' : 'combobox-placeholder'">
-                  {{ inputData.selectedIndex || $t('import.selectOrCreateIndex') }}
-                </span>
-                <span class="i-carbon-chevron-down h-4 w-4 combobox-icon" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent class="combobox-content" :align="'start'">
-              <div class="combobox-search">
-                <Input
-                  v-model="inputData.indexSearchQuery"
-                  :placeholder="$t('import.selectOrCreateIndex')"
-                  class="combobox-input"
-                  @keydown.enter="handleIndexInputEnter"
-                />
-              </div>
-              <div class="combobox-list">
-                <!-- Existing options filtered by query -->
-                <div
-                  v-for="option in filteredIndexOptions"
-                  :key="option.value"
-                  :class="['combobox-item', { selected: option.value === inputData.selectedIndex }]"
-                  @click="selectIndexOption(option.value)"
-                >
-                  <span
-                    v-if="option.value === inputData.selectedIndex"
-                    class="i-carbon-checkmark h-4 w-4 combobox-check"
-                  />
-                  <span v-else class="combobox-check-placeholder" />
-                  {{ option.label }}
-                </div>
-
-                <!-- "Create new" option when query doesn't match any existing -->
-                <div
-                  v-if="inputData.indexSearchQuery && !exactMatchExists"
-                  class="combobox-item combobox-create"
-                  @click="selectIndexOption(inputData.indexSearchQuery)"
-                >
-                  <span class="i-carbon-add h-4 w-4 combobox-check" />
-                  {{ $t('import.createNew') }}: "{{ inputData.indexSearchQuery }}"
-                </div>
-
-                <div
-                  v-if="filteredIndexOptions.length === 0 && !inputData.indexSearchQuery"
-                  class="combobox-empty"
-                >
-                  {{ $t('import.noIndicesFound') }}
-                </div>
-              </div>
-            </PopoverContent>
-          </Popover>
-
+          <SearchableSelect
+            :model-value="inputData.selectedIndex"
+            :options="indexOptions"
+            :loading="loadingStat.index"
+            :placeholder="$t('import.selectOrCreateIndex')"
+            :disabled="!inputData.selectedConnection || loadingStat.connection"
+            :empty-text="$t('import.noIndicesFound')"
+            allow-create
+            :create-text="$t('import.createNew')"
+            :search-threshold="0"
+            class="w-full"
+            @update:model-value="handleIndexChange"
+            @open="isOpen => isOpen && handleIndexOpen()"
+          />
           <span class="field-hint">
             {{
               importIsNewCollection
@@ -122,17 +65,8 @@
 import { storeToRefs } from 'pinia';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Grid, GridItem } from '@/components/ui/grid';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { SearchableSelect } from '@/components/ui/combobox';
 import {
   useImportExportStore,
   useConnectionStore,
@@ -158,8 +92,6 @@ const { importConnection, importTargetIndex, importIsNewCollection } =
 const inputData = ref({
   selectedConnection: '',
   selectedIndex: '',
-  connectionSearchQuery: '',
-  indexSearchQuery: '',
 });
 
 const loadingStat = ref({
@@ -167,52 +99,12 @@ const loadingStat = ref({
   index: false,
 });
 
-const indexDropdownOpen = ref(false);
 const indexOptions = ref<Array<{ label: string; value: string }>>([]);
 const currentExistingIndices = ref<string[]>([]);
 
 const connectionOptions = computed(() =>
   connections.value.map(({ name }) => ({ label: name, value: name })),
 );
-
-const filteredConnectionOptions = computed(() => {
-  if (!inputData.value.connectionSearchQuery) {
-    return connectionOptions.value;
-  }
-  const query = inputData.value.connectionSearchQuery.toLowerCase();
-  return connectionOptions.value
-    .filter(option => option.value.toLowerCase().includes(query))
-    .sort((a, b) => a.value.localeCompare(b.value));
-});
-
-const filteredIndexOptions = computed(() => {
-  if (!inputData.value.indexSearchQuery) {
-    return indexOptions.value;
-  }
-  const query = inputData.value.indexSearchQuery.toLowerCase();
-  return indexOptions.value
-    .filter(option => option.value.toLowerCase().includes(query))
-    .sort((a, b) => a.value.localeCompare(b.value));
-});
-
-const exactMatchExists = computed(() => {
-  const query = inputData.value.indexSearchQuery.toLowerCase();
-  return indexOptions.value.some(opt => opt.value.toLowerCase() === query);
-});
-
-const selectIndexOption = (value: string) => {
-  inputData.value.selectedIndex = value;
-  inputData.value.indexSearchQuery = '';
-  indexDropdownOpen.value = false;
-  handleIndexChange(value);
-};
-
-const handleIndexInputEnter = () => {
-  const query = inputData.value.indexSearchQuery.trim();
-  if (query) {
-    selectIndexOption(query);
-  }
-};
 
 const handleConnectionOpen = async () => {
   loadingStat.value.connection = true;
@@ -396,91 +288,6 @@ watch(importTargetIndex, newIdx => {
 }
 
 .step-card .collection-indicator .indicator-text {
-  font-size: 12px;
-  color: hsl(var(--muted-foreground));
-}
-
-/* Combobox styles */
-.combobox-trigger {
-  width: 100%;
-  justify-content: space-between;
-  font-weight: 400;
-}
-
-.combobox-value {
-  color: hsl(var(--foreground));
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.combobox-placeholder {
-  color: hsl(var(--muted-foreground));
-}
-
-.combobox-icon {
-  margin-left: auto;
-  flex-shrink: 0;
-  opacity: 0.5;
-}
-
-.combobox-content {
-  padding: 4px;
-  min-width: 240px;
-}
-
-.combobox-search {
-  padding: 4px 4px 8px;
-}
-
-.combobox-input {
-  height: 32px;
-  font-size: 13px;
-}
-
-.combobox-list {
-  max-height: 200px;
-  overflow-y: auto;
-}
-
-.combobox-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-size: 13px;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.combobox-item:hover {
-  background: hsl(var(--accent));
-}
-
-.combobox-item.selected {
-  background: hsl(var(--accent));
-  font-weight: 500;
-}
-
-.combobox-item.combobox-create {
-  color: #18a058;
-  font-style: italic;
-}
-
-.combobox-check {
-  flex-shrink: 0;
-}
-
-.combobox-check-placeholder {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-
-.combobox-empty {
-  padding: 12px;
-  text-align: center;
   font-size: 12px;
   color: hsl(var(--muted-foreground));
 }

--- a/src/views/manage/components/alias-dialog.vue
+++ b/src/views/manage/components/alias-dialog.vue
@@ -251,10 +251,12 @@ const submitCreate = async (event: MouseEvent) => {
 };
 
 const indices = computed(() =>
-  indexWithAliases.value.map(index => ({
-    label: index.index,
-    value: index.index,
-  })),
+  indexWithAliases.value
+    .map(index => ({
+      label: index.index,
+      value: index.index,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label)),
 );
 
 defineExpose({ toggleModal });

--- a/src/views/manage/components/alias-dialog.vue
+++ b/src/views/manage/components/alias-dialog.vue
@@ -30,19 +30,12 @@
                 required
                 :error="getError('indexName', fieldErrors.indexName)"
               >
-                <Select
+                <SearchableSelect
                   v-model="formData.indexName"
-                  @update:open="(open: boolean) => !open && handleBlur('indexName')"
-                >
-                  <SelectTrigger>
-                    <SelectValue :placeholder="$t('manage.index.newAliasForm.indexName')" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem v-for="idx in indices" :key="idx.value" :value="idx.value">
-                      {{ idx.label }}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+                  :options="indices"
+                  :placeholder="$t('manage.index.newAliasForm.indexName')"
+                  @update:model-value="handleBlur('indexName')"
+                />
               </FormItem>
             </GridItem>
           </Grid>
@@ -153,13 +146,7 @@ import { InputNumber } from '@/components/ui/input-number';
 import { Form, FormItem } from '@/components/ui/form';
 import { Grid, GridItem } from '@/components/ui/grid';
 import { Collapse, CollapseItem } from '@/components/ui/collapse';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { SearchableSelect } from '@/components/ui/combobox';
 import { Switch } from '@/components/ui/switch';
 
 const clusterManageStore = useClusterManageStore();

--- a/src/views/manage/components/switch-alias-dialog.vue
+++ b/src/views/manage/components/switch-alias-dialog.vue
@@ -35,19 +35,12 @@
                 required
                 :error="getError('targetIndex', fieldErrors.targetIndex)"
               >
-                <Select
+                <SearchableSelect
                   v-model="formData.targetIndex"
-                  @update:open="(open: boolean) => !open && handleBlur('targetIndex')"
-                >
-                  <SelectTrigger>
-                    <SelectValue :placeholder="$t('manage.index.switchAliasForm.targetIndex')" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem v-for="idx in indices" :key="idx.value" :value="idx.value">
-                      {{ idx.label }}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+                  :options="indices"
+                  :placeholder="$t('manage.index.switchAliasForm.targetIndex')"
+                  @update:model-value="handleBlur('targetIndex')"
+                />
               </FormItem>
             </GridItem>
           </Grid>
@@ -82,13 +75,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Form, FormItem } from '@/components/ui/form';
 import { Grid, GridItem } from '@/components/ui/grid';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { SearchableSelect } from '@/components/ui/combobox';
 
 const clusterManageStore = useClusterManageStore();
 const { switchAlias, fetchAliases } = clusterManageStore;

--- a/src/views/manage/components/switch-alias-dialog.vue
+++ b/src/views/manage/components/switch-alias-dialog.vue
@@ -142,10 +142,12 @@ const submitCreate = async (event: MouseEvent) => {
 };
 
 const indices = computed(() =>
-  indexWithAliases.value.map(index => ({
-    label: index.index,
-    value: index.index,
-  })),
+  indexWithAliases.value
+    .map(index => ({
+      label: index.index,
+      value: index.index,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label)),
 );
 
 defineExpose({ toggleModal });


### PR DESCRIPTION
## Summary

Create a reusable SearchableSelect component to replace inconsistent dropdown implementations throughout the application, addressing issue #380.

### Unified UX
- Single searchable dropdown pattern with inline search input, scrollable list, and create-new support
- Fixed width for toolbar selectors (220px) prevents layout shift
- Always scrollable dropdown (max-height 280px)
- Clear empty state indicators with icons when filter has no matches
- Create-new support for import/export collection selection

### Code Reduction
- Removed ~320 lines of duplicated/inconsistent dropdown patterns, eliminated @ts-ignore hacks
- 9 Select instances replaced across toolbar, import/export, manage dialogs, and editor views

## Changes

### New Component
- `src/components/ui/combobox/SearchableSelect.vue` — unified searchable dropdown

### Refactored Files
| File | Changes |
|---|---|
| `tool-bar.vue` | 3 hacked Select → SearchableSelect + sorted options |
| `import-target-output.vue` | 1 Select + inline combobox → 2 SearchableSelect + sorted options + always-visible search |
| `export-source-scope.vue` | 2 Select → SearchableSelect + sorted options + always-visible search |
| `alias-dialog.vue` | index Select → SearchableSelect + sorted options |
| `switch-alias-dialog.vue` | target index Select → SearchableSelect + sorted options |
| `dynamodb-connect-dialog.vue` | AWS region Select → SearchableSelect |
| `ui-editor.vue` | DynamoDB index Select → SearchableSelect |

### UX Improvements
- Inline search input in trigger button (no duplicate input in dropdown)
- Fixed width for toolbar selectors (220px) prevents layout shift
- Always scrollable dropdown (max-height 280px)
- Clear empty state indicators with icons when filter has no matches
- Create-new support for import/export collection selection
- **All options sorted alphabetically** (connections, indices, tables)
- **Favorites shown first** for DynamoDB tables (sorted within each group)
- **Always-visible search** (`searchThreshold=0`) for all database/collection selectors

## Review Feedback Addressed
- `allowCreate` now shows when query has no exact match (not just when list is empty)
- "No results" empty state suppressed while loading spinner is shown
- Removed dead `.select-search-container` CSS from `tool-bar.vue`

## Test Plan
- Toolbar: Switch connections/indices/tables — verify width stability, search works, options sorted
- Import/Export: Select/create collections — verify create-new works, options sorted, search always visible
- Manage dialogs: Switch aliases — verify searchable index selection, options sorted
- DynamoDB connect: Select AWS region — verify searchable dropdown (order preserved: geographic)
- DynamoDB editor: Table/Index selection — verify order (Table first, then GSIs/LSIs preserved)

Refs #380