### PR TITLE
fix(searchdsl): improve auto-completion accuracy and coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/.claude/'],
   moduleNameMapper: {
     '^monaco-editor$': '<rootDir>/node_modules/monaco-editor/esm/vs/editor/editor.api.js',
   },

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,6 @@ module.exports = {
   testEnvironment: 'node',
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/.claude/'],
   moduleNameMapper: {
-    '^monaco-editor$': '<rootDir>/node_modules/monaco-editor/esm/vs/editor/editor.api.js',
+    '^monaco-editor(/.*)?$': '<rootDir>/node_modules/monaco-editor/esm/vs/editor/editor.api.js',
   },
 };

--- a/src/common/monaco/index.ts
+++ b/src/common/monaco/index.ts
@@ -1,4 +1,5 @@
 import * as monaco from 'monaco-editor';
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution';
 import {
   BackendType,
   configureCompletions,

--- a/src/common/monaco/searchdsl/apiSpec.ts
+++ b/src/common/monaco/searchdsl/apiSpec.ts
@@ -286,12 +286,79 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET', 'PUT'],
     description: 'Get or update index mappings',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Specify timeout for connection to master',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+      {
+        name: 'write_index_only',
+        type: 'boolean',
+        description: 'When true, applies mappings only to the write index of an alias',
+      },
+    ],
   },
   {
     path: '/{index}/_settings',
     methods: ['GET', 'PUT'],
     description: 'Get or update index settings',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      { name: 'flat_settings', type: 'boolean', description: 'Return settings in flat format' },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'include_defaults',
+        type: 'boolean',
+        description: 'Whether to return all default setting for each of the indices',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Specify timeout for connection to master',
+      },
+      {
+        name: 'preserve_existing',
+        type: 'boolean',
+        description:
+          'Whether to update existing settings. If set to true existing settings on an index remain unchanged',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+    ],
   },
   {
     path: '/{index}/_open',
@@ -572,12 +639,88 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_msearch',
     methods: ['GET', 'POST'],
     description: 'Execute multiple searches in one request',
+    queryParams: [
+      {
+        name: 'max_concurrent_searches',
+        type: 'integer',
+        description:
+          'Controls the maximum number of concurrent searches the multi search api will execute',
+      },
+      {
+        name: 'max_concurrent_shard_requests',
+        type: 'integer',
+        description:
+          'The number of concurrent shard requests each sub search executes concurrently',
+        default: 5,
+      },
+      {
+        name: 'pre_filter_shard_size',
+        type: 'integer',
+        description: 'Threshold that enforces a pre-filter roundtrip to prefilter search shards',
+      },
+      {
+        name: 'rest_total_hits_as_int',
+        type: 'boolean',
+        description: 'Indicates whether hits.total should be rendered as an integer or an object',
+        default: false,
+      },
+      {
+        name: 'search_type',
+        type: 'string',
+        description: 'Search operation type',
+        enum: ['query_then_fetch', 'dfs_query_then_fetch'],
+      },
+      {
+        name: 'typed_keys',
+        type: 'boolean',
+        description:
+          'Specify whether aggregation and suggester names should be prefixed by their respective types in the response',
+      },
+    ],
   },
   {
     path: '/{index}/_msearch',
     methods: ['GET', 'POST'],
     description: 'Multi search on specific index',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'max_concurrent_searches',
+        type: 'integer',
+        description:
+          'Controls the maximum number of concurrent searches the multi search api will execute',
+      },
+      {
+        name: 'max_concurrent_shard_requests',
+        type: 'integer',
+        description:
+          'The number of concurrent shard requests each sub search executes concurrently',
+        default: 5,
+      },
+      {
+        name: 'pre_filter_shard_size',
+        type: 'integer',
+        description: 'Threshold that enforces a pre-filter roundtrip to prefilter search shards',
+      },
+      {
+        name: 'rest_total_hits_as_int',
+        type: 'boolean',
+        description: 'Indicates whether hits.total should be rendered as an integer or an object',
+        default: false,
+      },
+      {
+        name: 'search_type',
+        type: 'string',
+        description: 'Search operation type',
+        enum: ['query_then_fetch', 'dfs_query_then_fetch'],
+      },
+      {
+        name: 'typed_keys',
+        type: 'boolean',
+        description:
+          'Specify whether aggregation and suggester names should be prefixed by their respective types in the response',
+      },
+    ],
   },
 
   // Explain API

--- a/src/common/monaco/searchdsl/apiSpec.ts
+++ b/src/common/monaco/searchdsl/apiSpec.ts
@@ -315,6 +315,11 @@ const commonEndpoints: ApiEndpoint[] = [
         type: 'boolean',
         description: 'When true, applies mappings only to the write index of an alias',
       },
+      {
+        name: 'include_defaults',
+        type: 'boolean',
+        description: 'Whether to return all default mapping settings',
+      },
     ],
   },
   {
@@ -365,24 +370,132 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['POST'],
     description: 'Open a closed index',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+      {
+        name: 'wait_for_active_shards',
+        type: 'string',
+        description: 'Number of shard copies that must be active before proceeding',
+      },
+    ],
   },
   {
     path: '/{index}/_close',
     methods: ['POST'],
     description: 'Close an index',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+      {
+        name: 'wait_for_active_shards',
+        type: 'string',
+        description: 'Number of shard copies that must be active before proceeding',
+      },
+    ],
   },
   {
     path: '/{index}/_refresh',
     methods: ['POST'],
     description: 'Refresh an index',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+    ],
   },
   {
     path: '/{index}/_flush',
     methods: ['POST'],
     description: 'Flush an index',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'force',
+        type: 'boolean',
+        description: 'Force flush even if there are no changes to commit',
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'wait_if_ongoing',
+        type: 'boolean',
+        description: 'Block until flush completes if another flush is running',
+      },
+    ],
   },
   {
     path: '/{index}/_forcemerge',
@@ -426,6 +539,55 @@ const commonEndpoints: ApiEndpoint[] = [
       { name: 'index', type: 'string', description: 'Index name', required: true },
       { name: 'alias', type: 'string', description: 'Alias name', required: true },
     ],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+    ],
+  },
+  {
+    path: '/{index}/_alias',
+    methods: ['GET'],
+    description: 'Get all aliases for an index',
+    pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+    ],
   },
 
   // Cat APIs
@@ -434,7 +596,12 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List indices',
     queryParams: [
-      { name: 'format', type: 'string', description: 'Output format', enum: ['text', 'json'] },
+      {
+        name: 'format',
+        type: 'string',
+        description: 'Output format',
+        enum: ['text', 'json', 'yaml', 'cbor', 'smile'],
+      },
       { name: 'h', type: 'string', description: 'Columns to display' },
       { name: 's', type: 'string', description: 'Sort by column' },
       { name: 'v', type: 'boolean', description: 'Verbose output' },
@@ -451,7 +618,12 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'Cluster health',
     queryParams: [
-      { name: 'format', type: 'string', description: 'Output format', enum: ['text', 'json'] },
+      {
+        name: 'format',
+        type: 'string',
+        description: 'Output format',
+        enum: ['text', 'json', 'yaml', 'cbor', 'smile'],
+      },
       { name: 'v', type: 'boolean', description: 'Verbose output' },
     ],
   },
@@ -460,7 +632,12 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List nodes',
     queryParams: [
-      { name: 'format', type: 'string', description: 'Output format', enum: ['text', 'json'] },
+      {
+        name: 'format',
+        type: 'string',
+        description: 'Output format',
+        enum: ['text', 'json', 'yaml', 'cbor', 'smile'],
+      },
       { name: 'h', type: 'string', description: 'Columns to display' },
       { name: 'v', type: 'boolean', description: 'Verbose output' },
     ],
@@ -470,7 +647,12 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List shards',
     queryParams: [
-      { name: 'format', type: 'string', description: 'Output format', enum: ['text', 'json'] },
+      {
+        name: 'format',
+        type: 'string',
+        description: 'Output format',
+        enum: ['text', 'json', 'yaml', 'cbor', 'smile'],
+      },
       { name: 'h', type: 'string', description: 'Columns to display' },
       { name: 'v', type: 'boolean', description: 'Verbose output' },
     ],
@@ -480,7 +662,12 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List aliases',
     queryParams: [
-      { name: 'format', type: 'string', description: 'Output format', enum: ['text', 'json'] },
+      {
+        name: 'format',
+        type: 'string',
+        description: 'Output format',
+        enum: ['text', 'json', 'yaml', 'cbor', 'smile'],
+      },
       { name: 'v', type: 'boolean', description: 'Verbose output' },
     ],
   },
@@ -489,7 +676,12 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List templates',
     queryParams: [
-      { name: 'format', type: 'string', description: 'Output format', enum: ['text', 'json'] },
+      {
+        name: 'format',
+        type: 'string',
+        description: 'Output format',
+        enum: ['text', 'json', 'yaml', 'cbor', 'smile'],
+      },
       { name: 'v', type: 'boolean', description: 'Verbose output' },
     ],
   },
@@ -498,7 +690,12 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'Shard allocation',
     queryParams: [
-      { name: 'format', type: 'string', description: 'Output format', enum: ['text', 'json'] },
+      {
+        name: 'format',
+        type: 'string',
+        description: 'Output format',
+        enum: ['text', 'json', 'yaml', 'cbor', 'smile'],
+      },
       { name: 'v', type: 'boolean', description: 'Verbose output' },
     ],
   },
@@ -528,16 +725,78 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_cluster/state',
     methods: ['GET'],
     description: 'Cluster state',
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      { name: 'flat_settings', type: 'boolean', description: 'Return settings in flat format' },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'local',
+        type: 'boolean',
+        description: 'Return local information, do not retrieve from master node',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for waiting for new cluster state',
+      },
+      {
+        name: 'wait_for_metadata_version',
+        type: 'string',
+        description: 'Wait for metadata version to be equal or greater than specified',
+      },
+      {
+        name: 'wait_for_timeout',
+        type: 'string',
+        description: 'Maximum time to wait for wait_for_metadata_version before timing out',
+      },
+    ],
   },
   {
     path: '/_cluster/stats',
     methods: ['GET'],
     description: 'Cluster stats',
+    queryParams: [
+      {
+        name: 'include_remotes',
+        type: 'boolean',
+        description: 'Include remote cluster data in response',
+      },
+      { name: 'timeout', type: 'string', description: 'Period to wait for each node to respond' },
+    ],
   },
   {
     path: '/_cluster/settings',
     methods: ['GET', 'PUT'],
     description: 'Cluster settings',
+    queryParams: [
+      { name: 'flat_settings', type: 'boolean', description: 'Return settings in flat format' },
+      {
+        name: 'include_defaults',
+        type: 'boolean',
+        description: 'Return all default cluster setting values',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+    ],
     requestBody: {
       properties: {
         persistent: { type: 'object', description: 'Persistent settings' },
@@ -549,11 +808,56 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_cluster/allocation/explain',
     methods: ['GET', 'POST'],
     description: 'Explain shard allocation',
+    queryParams: [
+      {
+        name: 'include_disk_info',
+        type: 'boolean',
+        description: 'If true, returns information about disk usage and shard sizes',
+      },
+      {
+        name: 'include_yes_decisions',
+        type: 'boolean',
+        description: 'If true, returns YES decisions in explanation',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+    ],
   },
   {
     path: '/_cluster/reroute',
     methods: ['POST'],
     description: 'Reroute shards',
+    queryParams: [
+      {
+        name: 'dry_run',
+        type: 'boolean',
+        description: 'Simulate the operation without actually performing it',
+      },
+      {
+        name: 'explain',
+        type: 'boolean',
+        description: 'Return explanation of why commands can or cannot run',
+      },
+      {
+        name: 'metric',
+        type: 'string',
+        description: 'Limit information returned to specified metrics',
+      },
+      {
+        name: 'retry_failed',
+        type: 'boolean',
+        description: 'Retry allocation of shards blocked due to too many failures',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+    ],
   },
 
   // Nodes APIs
@@ -561,16 +865,94 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_nodes',
     methods: ['GET'],
     description: 'Node information',
+    queryParams: [
+      { name: 'flat_settings', type: 'boolean', description: 'Return settings in flat format' },
+      { name: 'timeout', type: 'string', description: 'Period to wait for a response' },
+    ],
   },
   {
     path: '/_nodes/stats',
     methods: ['GET'],
     description: 'Node stats',
+    queryParams: [
+      {
+        name: 'completion_fields',
+        type: 'string',
+        description:
+          'Comma-separated list of fields to include in fielddata and suggest statistics',
+      },
+      {
+        name: 'fielddata_fields',
+        type: 'string',
+        description: 'Comma-separated list of fields to include in fielddata statistics',
+      },
+      {
+        name: 'fields',
+        type: 'string',
+        description: 'Comma-separated list of fields to include in statistics',
+      },
+      {
+        name: 'groups',
+        type: 'boolean',
+        description: 'Comma-separated list of search groups to include in search statistics',
+      },
+      {
+        name: 'include_segment_file_sizes',
+        type: 'boolean',
+        description: 'Report aggregated disk usage of each Lucene index file',
+      },
+      {
+        name: 'level',
+        type: 'string',
+        description:
+          'Indicates whether statistics are aggregated at the node, indices, or shards level',
+      },
+      { name: 'timeout', type: 'string', description: 'Period to wait for a response' },
+      {
+        name: 'types',
+        type: 'string',
+        description: 'Comma-separated list of document types for the indexing index metric',
+      },
+      {
+        name: 'include_unloaded_segments',
+        type: 'boolean',
+        description: 'If true, response includes information from segments not loaded into memory',
+      },
+    ],
   },
   {
     path: '/_nodes/hot_threads',
     methods: ['GET'],
     description: 'Hot threads',
+    queryParams: [
+      {
+        name: 'ignore_idle_threads',
+        type: 'boolean',
+        description: 'Filter out known idle threads',
+        default: true,
+      },
+      {
+        name: 'interval',
+        type: 'string',
+        description: 'Interval between thread stacktrace samples',
+        default: '500ms',
+      },
+      {
+        name: 'snapshots',
+        type: 'integer',
+        description: 'Number of samples of thread stacktrace',
+        default: 10,
+      },
+      {
+        name: 'threads',
+        type: 'integer',
+        description: 'Number of hot threads to provide information for',
+        default: 3,
+      },
+      { name: 'timeout', type: 'string', description: 'Period to wait for a response' },
+      { name: 'type', type: 'string', description: 'The type to sample' },
+      { name: 'sort', type: 'string', description: "Sort order for 'cpu' type" },
+    ],
   },
 
   // Template APIs
@@ -581,6 +963,15 @@ const commonEndpoints: ApiEndpoint[] = [
     pathParams: [
       { name: 'template', type: 'string', description: 'Template name', required: true },
     ],
+    queryParams: [
+      { name: 'flat_settings', type: 'boolean', description: 'Return settings in flat format' },
+      { name: 'local', type: 'boolean', description: 'Return information from local node only' },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+    ],
   },
   {
     path: '/_index_template/{template}',
@@ -589,6 +980,20 @@ const commonEndpoints: ApiEndpoint[] = [
     pathParams: [
       { name: 'template', type: 'string', description: 'Template name', required: true },
     ],
+    queryParams: [
+      { name: 'local', type: 'boolean', description: 'Return information from local node only' },
+      { name: 'flat_settings', type: 'boolean', description: 'Return settings in flat format' },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      {
+        name: 'include_defaults',
+        type: 'boolean',
+        description: 'Return all relevant default configurations for the index template',
+      },
+    ],
   },
   {
     path: '/_component_template/{template}',
@@ -596,6 +1001,20 @@ const commonEndpoints: ApiEndpoint[] = [
     description: 'Component templates',
     pathParams: [
       { name: 'template', type: 'string', description: 'Template name', required: true },
+    ],
+    queryParams: [
+      { name: 'flat_settings', type: 'boolean', description: 'Return settings in flat format' },
+      {
+        name: 'include_defaults',
+        type: 'boolean',
+        description: 'Return all default configurations for the component template',
+      },
+      { name: 'local', type: 'boolean', description: 'Return information from local node only' },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
     ],
   },
 
@@ -620,6 +1039,9 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET', 'POST'],
     description: 'Analyze text using index analyzer',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      { name: 'index', type: 'string', description: 'Index used to derive the analyzer' },
+    ],
   },
 
   // Validate API
@@ -629,8 +1051,61 @@ const commonEndpoints: ApiEndpoint[] = [
     description: 'Validate a query',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
     queryParams: [
-      { name: 'explain', type: 'boolean', description: 'Explain query validation' },
-      { name: 'rewrite', type: 'boolean', description: 'Rewrite query' },
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'all_shards',
+        type: 'boolean',
+        description: 'Execute validation on all shards instead of one random shard',
+      },
+      { name: 'analyzer', type: 'string', description: 'Analyzer to use for the query string' },
+      {
+        name: 'analyze_wildcard',
+        type: 'boolean',
+        description: 'If true, wildcard and prefix queries are analyzed',
+      },
+      {
+        name: 'default_operator',
+        type: 'string',
+        description: 'Default operator for query string query',
+        enum: ['AND', 'OR'],
+      },
+      {
+        name: 'df',
+        type: 'string',
+        description: 'Field to use as default where no field prefix is given in query string',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'explain',
+        type: 'boolean',
+        description: 'Return detailed information if an error has occurred',
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'lenient',
+        type: 'boolean',
+        description: 'If true, format-based query failures in query string will be ignored',
+      },
+      {
+        name: 'rewrite',
+        type: 'boolean',
+        description: 'Return a more detailed explanation showing the actual Lucene query',
+      },
+      { name: 'q', type: 'string', description: 'Query in the Lucene query string syntax' },
     ],
   },
 
@@ -732,6 +1207,45 @@ const commonEndpoints: ApiEndpoint[] = [
       { name: 'index', type: 'string', description: 'Index name', required: true },
       { name: 'id', type: 'string', description: 'Document ID', required: true },
     ],
+    queryParams: [
+      { name: 'analyzer', type: 'string', description: 'Analyzer to use for the query string' },
+      {
+        name: 'analyze_wildcard',
+        type: 'boolean',
+        description: 'If true, wildcard and prefix queries are analyzed',
+      },
+      {
+        name: 'default_operator',
+        type: 'string',
+        description: 'Default operator for query string query',
+        enum: ['AND', 'OR'],
+      },
+      { name: 'df', type: 'string', description: 'Default field for query string' },
+      {
+        name: 'lenient',
+        type: 'boolean',
+        description: 'If true, format-based query failures in query string will be ignored',
+      },
+      {
+        name: 'preference',
+        type: 'string',
+        description: 'Node or shard to perform the operation on',
+      },
+      { name: 'routing', type: 'string', description: 'Custom routing value' },
+      { name: '_source', type: 'string', description: 'Source fields to return' },
+      {
+        name: '_source_excludes',
+        type: 'string',
+        description: 'Source fields to exclude from response',
+      },
+      {
+        name: '_source_includes',
+        type: 'string',
+        description: 'Source fields to include in response',
+      },
+      { name: 'stored_fields', type: 'string', description: 'Stored fields to return in response' },
+      { name: 'q', type: 'string', description: 'Query in the Lucene query string syntax' },
+    ],
   },
 
   // Terms Enum API
@@ -828,6 +1342,14 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_snapshot',
     methods: ['GET'],
     description: 'List snapshot repositories',
+    queryParams: [
+      { name: 'local', type: 'boolean', description: 'Return information from local node only' },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+    ],
   },
   {
     path: '/_snapshot/{repository}',
@@ -835,6 +1357,14 @@ const commonEndpoints: ApiEndpoint[] = [
     description: 'Manage snapshot repository',
     pathParams: [
       { name: 'repository', type: 'string', description: 'Repository name', required: true },
+    ],
+    queryParams: [
+      { name: 'local', type: 'boolean', description: 'Return information from local node only' },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
     ],
   },
   {
@@ -845,6 +1375,42 @@ const commonEndpoints: ApiEndpoint[] = [
       { name: 'repository', type: 'string', description: 'Repository name', required: true },
       { name: 'snapshot', type: 'string', description: 'Snapshot name', required: true },
     ],
+    queryParams: [
+      { name: 'after', type: 'string', description: 'Offset identifier to start pagination from' },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'If false, request returns error for unavailable snapshots',
+      },
+      {
+        name: 'index_details',
+        type: 'boolean',
+        description: 'If true, response includes additional index information',
+      },
+      {
+        name: 'index_names',
+        type: 'boolean',
+        description: 'If true, response includes name of each index in each snapshot',
+      },
+      {
+        name: 'include_repository',
+        type: 'boolean',
+        description: 'If true, response includes repository name in each snapshot',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      { name: 'order', type: 'string', description: 'Sort order', enum: ['asc', 'desc'] },
+      { name: 'size', type: 'integer', description: 'Maximum number of snapshots to return' },
+      { name: 'sort', type: 'string', description: 'Sort column for results' },
+      {
+        name: 'verbose',
+        type: 'boolean',
+        description: 'Return additional information about each snapshot',
+      },
+    ],
   },
   {
     path: '/_snapshot/{repository}/{snapshot}/_restore',
@@ -853,6 +1419,18 @@ const commonEndpoints: ApiEndpoint[] = [
     pathParams: [
       { name: 'repository', type: 'string', description: 'Repository name', required: true },
       { name: 'snapshot', type: 'string', description: 'Snapshot name', required: true },
+    ],
+    queryParams: [
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      {
+        name: 'wait_for_completion',
+        type: 'boolean',
+        description: 'If true, request returns response when restore operation completes',
+      },
     ],
   },
 
@@ -877,12 +1455,42 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'Get task status',
     pathParams: [{ name: 'task_id', type: 'string', description: 'Task ID', required: true }],
+    queryParams: [
+      { name: 'timeout', type: 'string', description: 'Period to wait for a response' },
+      {
+        name: 'wait_for_completion',
+        type: 'boolean',
+        description: 'If true, request blocks until the task has completed',
+      },
+    ],
   },
   {
     path: '/_tasks/{task_id}/_cancel',
     methods: ['POST'],
     description: 'Cancel task',
     pathParams: [{ name: 'task_id', type: 'string', description: 'Task ID', required: true }],
+    queryParams: [
+      {
+        name: 'actions',
+        type: 'string',
+        description: 'Comma-separated list of actions used to limit the request',
+      },
+      {
+        name: 'nodes',
+        type: 'string',
+        description: 'Comma-separated list of node IDs or names used to limit the request',
+      },
+      {
+        name: 'parent_task_id',
+        type: 'string',
+        description: 'Parent task ID used to limit the tasks',
+      },
+      {
+        name: 'wait_for_completion',
+        type: 'boolean',
+        description: 'If true, request blocks until all found tasks are complete',
+      },
+    ],
   },
 
   // Ingest APIs
@@ -890,17 +1498,54 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_ingest/pipeline',
     methods: ['GET'],
     description: 'List ingest pipelines',
+    queryParams: [
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      {
+        name: 'summary',
+        type: 'boolean',
+        description: 'Return pipelines without their definitions',
+      },
+    ],
   },
   {
     path: '/_ingest/pipeline/{pipeline}',
     methods: ['GET', 'PUT', 'DELETE'],
     description: 'Manage ingest pipeline',
     pathParams: [{ name: 'pipeline', type: 'string', description: 'Pipeline ID', required: true }],
+    queryParams: [
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+      {
+        name: 'if_version',
+        type: 'integer',
+        description: 'Required version for optimistic concurrency control',
+      },
+      {
+        name: 'summary',
+        type: 'boolean',
+        description: 'Return pipelines without their definitions',
+      },
+    ],
   },
   {
     path: '/_ingest/pipeline/_simulate',
     methods: ['GET', 'POST'],
     description: 'Simulate pipeline',
+    queryParams: [
+      {
+        name: 'verbose',
+        type: 'boolean',
+        description: 'If true, response includes output data for each processor',
+      },
+    ],
   },
 
   // Script APIs
@@ -909,6 +1554,13 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET', 'PUT', 'DELETE'],
     description: 'Manage stored script',
     pathParams: [{ name: 'id', type: 'string', description: 'Script ID', required: true }],
+    queryParams: [
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+    ],
   },
 
   // Field Caps API
@@ -925,6 +1577,50 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET', 'POST'],
     description: 'Field capabilities for index',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'fields',
+        type: 'string',
+        description: 'Comma-separated list of fields to retrieve capabilities for',
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'include_unmapped',
+        type: 'boolean',
+        description: 'If true, unmapped fields are included in response',
+      },
+      {
+        name: 'filters',
+        type: 'string',
+        description: 'Comma-separated list of filters to apply to the response',
+      },
+      {
+        name: 'types',
+        type: 'string',
+        description: 'Comma-separated list of field types to include',
+      },
+      {
+        name: 'include_empty_fields',
+        type: 'boolean',
+        description: 'If false, empty fields are not included in response',
+      },
+    ],
   },
 
   // Scroll API
@@ -932,6 +1628,19 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_search/scroll',
     methods: ['GET', 'POST', 'DELETE'],
     description: 'Scroll search results',
+    queryParams: [
+      {
+        name: 'scroll',
+        type: 'string',
+        description: 'Period to retain the search context for scrolling',
+      },
+      { name: 'scroll_id', type: 'string', description: 'Scroll ID' },
+      {
+        name: 'rest_total_hits_as_int',
+        type: 'boolean',
+        description: 'If true, hits.total is returned as an integer',
+      },
+    ],
     requestBody: {
       properties: {
         scroll_id: { type: 'string', description: 'Scroll ID' },
@@ -945,12 +1654,66 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_cache/clear',
     methods: ['POST'],
     description: 'Clear cluster cache',
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      { name: 'fielddata', type: 'boolean', description: 'If true, clears the fields cache' },
+      {
+        name: 'fields',
+        type: 'string',
+        description: 'Comma-separated list of field names to limit fielddata cache clearing',
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      { name: 'query', type: 'boolean', description: 'If true, clears the query cache' },
+      { name: 'request', type: 'boolean', description: 'If true, clears the request cache' },
+    ],
   },
   {
     path: '/{index}/_cache/clear',
     methods: ['POST'],
     description: 'Clear index cache',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      { name: 'fielddata', type: 'boolean', description: 'If true, clears the fields cache' },
+      {
+        name: 'fields',
+        type: 'string',
+        description: 'Comma-separated list of field names to limit fielddata cache clearing',
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      { name: 'query', type: 'boolean', description: 'If true, clears the query cache' },
+      { name: 'request', type: 'boolean', description: 'If true, clears the request cache' },
+    ],
   },
 
   // Recovery API
@@ -959,6 +1722,35 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'Index recovery status',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'active_only',
+        type: 'boolean',
+        description: 'If true, response only includes ongoing shard recoveries',
+      },
+      {
+        name: 'detailed',
+        type: 'boolean',
+        description: 'If true, response includes detailed information about shard recoveries',
+      },
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+    ],
   },
 
   // Segments API
@@ -967,6 +1759,25 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'Index segments',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+    ],
   },
 
   // Stats APIs
@@ -974,12 +1785,112 @@ const commonEndpoints: ApiEndpoint[] = [
     path: '/_stats',
     methods: ['GET'],
     description: 'Cluster statistics',
+    queryParams: [
+      {
+        name: 'completion_fields',
+        type: 'string',
+        description:
+          'Comma-separated list of fields to include in fielddata and suggest statistics',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'fielddata_fields',
+        type: 'string',
+        description: 'Comma-separated list of fields to include in fielddata statistics',
+      },
+      {
+        name: 'fields',
+        type: 'string',
+        description: 'Comma-separated list of fields to include in statistics',
+      },
+      {
+        name: 'forbid_closed_indices',
+        type: 'boolean',
+        description: 'If true, statistics are not collected from closed indices',
+      },
+      {
+        name: 'groups',
+        type: 'string',
+        description: 'Comma-separated list of search groups to include in search statistics',
+      },
+      {
+        name: 'include_segment_file_sizes',
+        type: 'boolean',
+        description: 'Report aggregated disk usage of each Lucene index file',
+      },
+      {
+        name: 'include_unloaded_segments',
+        type: 'boolean',
+        description: 'If true, response includes information from segments not loaded into memory',
+      },
+      {
+        name: 'level',
+        type: 'string',
+        description:
+          'Indicates whether statistics are aggregated at cluster, indices, or shards level',
+      },
+    ],
   },
   {
     path: '/{index}/_stats',
     methods: ['GET'],
     description: 'Index statistics',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'completion_fields',
+        type: 'string',
+        description:
+          'Comma-separated list of fields to include in fielddata and suggest statistics',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'fielddata_fields',
+        type: 'string',
+        description: 'Comma-separated list of fields to include in fielddata statistics',
+      },
+      {
+        name: 'fields',
+        type: 'string',
+        description: 'Comma-separated list of fields to include in statistics',
+      },
+      {
+        name: 'forbid_closed_indices',
+        type: 'boolean',
+        description: 'If true, statistics are not collected from closed indices',
+      },
+      {
+        name: 'groups',
+        type: 'string',
+        description: 'Comma-separated list of search groups to include in search statistics',
+      },
+      {
+        name: 'include_segment_file_sizes',
+        type: 'boolean',
+        description: 'Report aggregated disk usage of each Lucene index file',
+      },
+      {
+        name: 'include_unloaded_segments',
+        type: 'boolean',
+        description: 'If true, response includes information from segments not loaded into memory',
+      },
+      {
+        name: 'level',
+        type: 'string',
+        description:
+          'Indicates whether statistics are aggregated at cluster, indices, or shards level',
+      },
+    ],
   },
 
   // Search Shards API
@@ -988,6 +1899,37 @@ const commonEndpoints: ApiEndpoint[] = [
     methods: ['GET', 'POST'],
     description: 'Search shards routing',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      { name: 'local', type: 'boolean', description: 'Return information from local node only' },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      {
+        name: 'preference',
+        type: 'string',
+        description: 'Node or shard to perform the operation on',
+      },
+      { name: 'routing', type: 'string', description: 'Custom routing value' },
+    ],
   },
 ];
 
@@ -1002,6 +1944,55 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'EQL search',
     pathParams: [{ name: 'index', type: 'string', description: 'Index name', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '7.9.0' } },
+    queryParams: [
+      {
+        name: 'allow_no_indices',
+        type: 'boolean',
+        description:
+          'Whether to ignore if a wildcard indices expression resolves into no concrete indices',
+      },
+      {
+        name: 'allow_partial_search_results',
+        type: 'boolean',
+        description: 'If true, returns partial results if there are shard failures',
+      },
+      {
+        name: 'allow_partial_sequence_results',
+        type: 'boolean',
+        description: 'If true, sequence queries return partial results in case of shard failures',
+      },
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Whether to expand wildcard expression to concrete indices',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'ccs_minimize_roundtrips',
+        type: 'boolean',
+        description: 'Minimize network round-trips for cross-cluster search',
+      },
+      {
+        name: 'ignore_unavailable',
+        type: 'boolean',
+        description: 'Whether specified concrete indices should be ignored when unavailable',
+      },
+      {
+        name: 'keep_alive',
+        type: 'string',
+        description: 'Period for which search and results are stored on cluster',
+      },
+      {
+        name: 'keep_on_completion',
+        type: 'boolean',
+        description: 'If true, search and results are stored on cluster',
+      },
+      {
+        name: 'wait_for_completion_timeout',
+        type: 'string',
+        description: 'Timeout to wait for request to finish',
+      },
+    ],
   },
 
   // SQL
@@ -1010,6 +2001,14 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     methods: ['GET', 'POST'],
     description: 'SQL query',
     availability: { [BackendType.ELASTICSEARCH]: { min: '6.3.0' } },
+    queryParams: [
+      {
+        name: 'format',
+        type: 'string',
+        description: 'Response format',
+        enum: ['csv', 'json', 'tsv', 'txt', 'yaml'],
+      },
+    ],
     requestBody: {
       properties: {
         query: { type: 'string', description: 'SQL query' },
@@ -1029,6 +2028,20 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List transforms',
     availability: { [BackendType.ELASTICSEARCH]: { min: '7.2.0' } },
+    queryParams: [
+      {
+        name: 'allow_no_match',
+        type: 'boolean',
+        description: 'If false, request returns 404 when no transforms match',
+      },
+      { name: 'from', type: 'integer', description: 'Skips the specified number of transforms' },
+      { name: 'size', type: 'integer', description: 'Maximum number of transforms to obtain' },
+      {
+        name: 'exclude_generated',
+        type: 'boolean',
+        description: 'Exclude automatically added fields from configuration',
+      },
+    ],
   },
   {
     path: '/_transform/{transform_id}',
@@ -1038,6 +2051,26 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
       { name: 'transform_id', type: 'string', description: 'Transform ID', required: true },
     ],
     availability: { [BackendType.ELASTICSEARCH]: { min: '7.2.0' } },
+    queryParams: [
+      {
+        name: 'allow_no_match',
+        type: 'boolean',
+        description: 'If false, request returns 404 when no transforms match',
+      },
+      { name: 'from', type: 'integer', description: 'Skips the specified number of transforms' },
+      { name: 'size', type: 'integer', description: 'Maximum number of transforms to obtain' },
+      {
+        name: 'exclude_generated',
+        type: 'boolean',
+        description: 'Exclude automatically added fields from configuration',
+      },
+      {
+        name: 'defer_validation',
+        type: 'boolean',
+        description: 'Skip validations during transform creation',
+      },
+      { name: 'timeout', type: 'string', description: 'Period to wait for a response' },
+    ],
   },
 
   // Data Stream APIs
@@ -1046,6 +2079,30 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List data streams',
     availability: { [BackendType.ELASTICSEARCH]: { min: '7.9.0' } },
+    queryParams: [
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Type of data stream that wildcard patterns can match',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'include_defaults',
+        type: 'boolean',
+        description: 'If true, returns all relevant default configurations for the index template',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      {
+        name: 'verbose',
+        type: 'boolean',
+        description:
+          'Whether the maximum timestamp for each data stream should be calculated and returned',
+      },
+    ],
   },
   {
     path: '/_data_stream/{data_stream}',
@@ -1055,6 +2112,30 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
       { name: 'data_stream', type: 'string', description: 'Data stream name', required: true },
     ],
     availability: { [BackendType.ELASTICSEARCH]: { min: '7.9.0' } },
+    queryParams: [
+      {
+        name: 'expand_wildcards',
+        type: 'string',
+        description: 'Type of data stream that wildcard patterns can match',
+        enum: ['open', 'closed', 'hidden', 'none', 'all'],
+      },
+      {
+        name: 'include_defaults',
+        type: 'boolean',
+        description: 'If true, returns all relevant default configurations for the index template',
+      },
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      {
+        name: 'verbose',
+        type: 'boolean',
+        description:
+          'Whether the maximum timestamp for each data stream should be calculated and returned',
+      },
+    ],
   },
 
   // ILM (Index Lifecycle Management)
@@ -1063,6 +2144,14 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List ILM policies',
     availability: { [BackendType.ELASTICSEARCH]: { min: '6.6.0' } },
+    queryParams: [
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+    ],
   },
   {
     path: '/_ilm/policy/{policy}',
@@ -1070,6 +2159,14 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'Manage ILM policy',
     pathParams: [{ name: 'policy', type: 'string', description: 'Policy name', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '6.6.0' } },
+    queryParams: [
+      {
+        name: 'master_timeout',
+        type: 'string',
+        description: 'Timeout for connection to master node',
+      },
+      { name: 'timeout', type: 'string', description: 'Explicit operation timeout' },
+    ],
   },
 
   // Rollup APIs
@@ -1079,6 +2176,15 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'Manage rollup job',
     pathParams: [{ name: 'job_id', type: 'string', description: 'Job ID', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '6.3.0' } },
+    queryParams: [
+      {
+        name: 'allow_no_match',
+        type: 'boolean',
+        description: 'If false, request returns 404 when no rollup jobs match',
+      },
+      { name: 'from', type: 'integer', description: 'Skips the specified number of rollup jobs' },
+      { name: 'size', type: 'integer', description: 'Maximum number of rollup jobs to obtain' },
+    ],
   },
 
   // Watcher APIs
@@ -1088,6 +2194,28 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'Manage watch',
     pathParams: [{ name: 'watch_id', type: 'string', description: 'Watch ID', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '5.0.0' } },
+    queryParams: [
+      {
+        name: 'active',
+        type: 'boolean',
+        description: 'Whether the watch is in an active or inactive state',
+      },
+      {
+        name: 'if_primary_term',
+        type: 'integer',
+        description: 'Primary term for optimistic concurrency control',
+      },
+      {
+        name: 'if_seq_no',
+        type: 'integer',
+        description: 'Sequence number for optimistic concurrency control',
+      },
+      {
+        name: 'version',
+        type: 'integer',
+        description: 'Expected version number for concurrency control',
+      },
+    ],
   },
 
   // Cross-Cluster Replication
@@ -1112,6 +2240,20 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List anomaly detection jobs',
     availability: { [BackendType.ELASTICSEARCH]: { min: '5.4.0' } },
+    queryParams: [
+      {
+        name: 'allow_no_match',
+        type: 'boolean',
+        description: 'If false, request returns 404 when no jobs match',
+      },
+      { name: 'from', type: 'integer', description: 'Skips the specified number of jobs' },
+      { name: 'size', type: 'integer', description: 'Maximum number of jobs to obtain' },
+      {
+        name: 'exclude_generated',
+        type: 'boolean',
+        description: 'Indicates if certain fields should be removed from the configuration',
+      },
+    ],
   },
   {
     path: '/_ml/anomaly_detectors/{job_id}',
@@ -1119,12 +2261,68 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'Manage anomaly detection job',
     pathParams: [{ name: 'job_id', type: 'string', description: 'Job ID', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '5.4.0' } },
+    queryParams: [
+      {
+        name: 'allow_no_match',
+        type: 'boolean',
+        description: 'If false, request returns 404 when no jobs match',
+      },
+      {
+        name: 'exclude_generated',
+        type: 'boolean',
+        description: 'Indicates if certain fields should be removed from the configuration',
+      },
+      {
+        name: 'force',
+        type: 'boolean',
+        description: 'If true, the job is deleted even if it is not stopped',
+      },
+      {
+        name: 'wait_for_completion',
+        type: 'boolean',
+        description: 'If true, waits for job deletion to complete',
+      },
+    ],
   },
   {
     path: '/_ml/trained_models',
     methods: ['GET'],
     description: 'List trained models',
     availability: { [BackendType.ELASTICSEARCH]: { min: '7.10.0' } },
+    queryParams: [
+      {
+        name: 'allow_no_match',
+        type: 'boolean',
+        description: 'If false, request returns 404 when no models match',
+      },
+      {
+        name: 'decompress_definition',
+        type: 'boolean',
+        description: 'If true, the fields are decompress before returning',
+      },
+      {
+        name: 'exclude_generated',
+        type: 'boolean',
+        description: 'Indicates if certain fields should be removed from the configuration',
+      },
+      { name: 'from', type: 'integer', description: 'Skips the specified number of models' },
+      {
+        name: 'include',
+        type: 'string',
+        description: 'Comma-separated list of fields to include in results',
+      },
+      {
+        name: 'include_model_definition',
+        type: 'boolean',
+        description: 'If true, the definition field of the response is not base64 encoded',
+      },
+      { name: 'size', type: 'integer', description: 'Maximum number of models to obtain' },
+      {
+        name: 'tags',
+        type: 'string',
+        description: 'Comma-separated list of tags that the model must have',
+      },
+    ],
   },
   {
     path: '/_ml/trained_models/{model_id}',
@@ -1132,6 +2330,44 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'Get or delete trained model',
     pathParams: [{ name: 'model_id', type: 'string', description: 'Model ID', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '7.10.0' } },
+    queryParams: [
+      {
+        name: 'allow_no_match',
+        type: 'boolean',
+        description: 'If false, request returns 404 when no models match',
+      },
+      {
+        name: 'decompress_definition',
+        type: 'boolean',
+        description: 'If true, the fields are decompress before returning',
+      },
+      {
+        name: 'exclude_generated',
+        type: 'boolean',
+        description: 'Indicates if certain fields should be removed from the configuration',
+      },
+      {
+        name: 'include',
+        type: 'string',
+        description: 'Comma-separated list of fields to include in results',
+      },
+      {
+        name: 'include_model_definition',
+        type: 'boolean',
+        description: 'If true, the definition field of the response is not base64 encoded',
+      },
+      {
+        name: 'tags',
+        type: 'string',
+        description: 'Comma-separated list of tags that the model must have',
+      },
+      {
+        name: 'force',
+        type: 'boolean',
+        description: 'If true, forcefully deletes a model that is referenced by ingest pipelines',
+      },
+      { name: 'timeout', type: 'string', description: 'Period to wait for a response' },
+    ],
   },
   {
     path: '/_ml/trained_models/{model_id}/_infer',
@@ -1139,6 +2375,13 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'Infer using trained model',
     pathParams: [{ name: 'model_id', type: 'string', description: 'Model ID', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '7.10.0' } },
+    queryParams: [
+      {
+        name: 'timeout',
+        type: 'string',
+        description: 'Controls the amount of time to wait for inference results',
+      },
+    ],
   },
 
   // Security APIs
@@ -1147,6 +2390,13 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List users',
     availability: { [BackendType.ELASTICSEARCH]: { min: '5.0.0' } },
+    queryParams: [
+      {
+        name: 'with_profile_uid',
+        type: 'boolean',
+        description: 'If true, retrieves the User Profile UID for the users',
+      },
+    ],
   },
   {
     path: '/_security/user/{username}',
@@ -1154,6 +2404,19 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'Manage user',
     pathParams: [{ name: 'username', type: 'string', description: 'Username', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '5.0.0' } },
+    queryParams: [
+      {
+        name: 'refresh',
+        type: 'string',
+        description: 'If true, refresh the affected shards after performing the operation',
+        enum: ['true', 'false', 'wait_for'],
+      },
+      {
+        name: 'with_profile_uid',
+        type: 'boolean',
+        description: 'If true, retrieves the User Profile UID for the users',
+      },
+    ],
   },
   {
     path: '/_security/role',
@@ -1167,12 +2430,44 @@ const elasticsearchEndpoints: ApiEndpoint[] = [
     description: 'Manage role',
     pathParams: [{ name: 'role', type: 'string', description: 'Role name', required: true }],
     availability: { [BackendType.ELASTICSEARCH]: { min: '5.0.0' } },
+    queryParams: [
+      {
+        name: 'refresh',
+        type: 'string',
+        description: 'If true, refresh the affected shards after performing the operation',
+        enum: ['true', 'false', 'wait_for'],
+      },
+    ],
   },
   {
     path: '/_security/api_key',
     methods: ['GET', 'POST'],
     description: 'Manage API keys',
     availability: { [BackendType.ELASTICSEARCH]: { min: '6.7.0' } },
+    queryParams: [
+      { name: 'id', type: 'string', description: 'API key id of the API key to be retrieved' },
+      { name: 'name', type: 'string', description: 'API key name of the API key to be retrieved' },
+      {
+        name: 'owner',
+        type: 'boolean',
+        description: 'If true, only return API keys owned by the currently authenticated user',
+      },
+      {
+        name: 'realm_name',
+        type: 'string',
+        description: 'Realm name of the user who created the API key',
+      },
+      {
+        name: 'username',
+        type: 'string',
+        description: 'Username of the user who created the API key',
+      },
+      {
+        name: 'with_limited_by',
+        type: 'boolean',
+        description: "Return the snapshot of the owner user's role descriptors",
+      },
+    ],
   },
 ];
 
@@ -1213,6 +2508,10 @@ const opensearchEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List anomaly detectors',
     availability: { [BackendType.OPENSEARCH]: { min: '1.0.0' } },
+    queryParams: [
+      { name: 'from', type: 'integer', description: 'The number of detectors to skip' },
+      { name: 'size', type: 'integer', description: 'The number of detectors to return' },
+    ],
   },
   {
     path: '/_plugins/_anomaly_detection/detectors/{detector_id}',
@@ -1222,6 +2521,13 @@ const opensearchEndpoints: ApiEndpoint[] = [
       { name: 'detector_id', type: 'string', description: 'Detector ID', required: true },
     ],
     availability: { [BackendType.OPENSEARCH]: { min: '1.0.0' } },
+    queryParams: [
+      {
+        name: 'refresh',
+        type: 'boolean',
+        description: 'Whether to refresh the index after the operation',
+      },
+    ],
   },
 
   // Alerting
@@ -1230,6 +2536,18 @@ const opensearchEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List alerting monitors',
     availability: { [BackendType.OPENSEARCH]: { min: '1.0.0' } },
+    queryParams: [
+      { name: 'from', type: 'integer', description: 'The number of monitors to skip' },
+      { name: 'size', type: 'integer', description: 'The number of monitors to return' },
+      { name: 'sortField', type: 'string', description: 'The field to sort results on' },
+      {
+        name: 'sortOrder',
+        type: 'string',
+        description: 'The order to sort results in',
+        enum: ['asc', 'desc'],
+      },
+      { name: 'search', type: 'string', description: 'Search string to filter monitors' },
+    ],
   },
   {
     path: '/_plugins/_alerting/monitors/{monitor_id}',
@@ -1237,6 +2555,23 @@ const opensearchEndpoints: ApiEndpoint[] = [
     description: 'Manage alerting monitor',
     pathParams: [{ name: 'monitor_id', type: 'string', description: 'Monitor ID', required: true }],
     availability: { [BackendType.OPENSEARCH]: { min: '1.0.0' } },
+    queryParams: [
+      {
+        name: 'refresh',
+        type: 'boolean',
+        description: 'Whether to refresh the index after the operation',
+      },
+      {
+        name: 'if_seq_no',
+        type: 'integer',
+        description: 'Sequence number for optimistic concurrency control',
+      },
+      {
+        name: 'if_primary_term',
+        type: 'integer',
+        description: 'Primary term for optimistic concurrency control',
+      },
+    ],
   },
 
   // Index State Management
@@ -1245,6 +2580,10 @@ const opensearchEndpoints: ApiEndpoint[] = [
     methods: ['GET'],
     description: 'List ISM policies',
     availability: { [BackendType.OPENSEARCH]: { min: '1.0.0' } },
+    queryParams: [
+      { name: 'from', type: 'integer', description: 'The number of policies to skip' },
+      { name: 'size', type: 'integer', description: 'The number of policies to return' },
+    ],
   },
   {
     path: '/_plugins/_ism/policies/{policy}',
@@ -1252,6 +2591,18 @@ const opensearchEndpoints: ApiEndpoint[] = [
     description: 'Manage ISM policy',
     pathParams: [{ name: 'policy', type: 'string', description: 'Policy name', required: true }],
     availability: { [BackendType.OPENSEARCH]: { min: '1.0.0' } },
+    queryParams: [
+      {
+        name: 'if_seq_no',
+        type: 'integer',
+        description: 'Sequence number for optimistic concurrency control',
+      },
+      {
+        name: 'if_primary_term',
+        type: 'integer',
+        description: 'Primary term for optimistic concurrency control',
+      },
+    ],
   },
 
   // Security
@@ -1309,6 +2660,20 @@ const opensearchEndpoints: ApiEndpoint[] = [
     methods: ['POST'],
     description: 'Create asynchronous search',
     availability: { [BackendType.OPENSEARCH]: { min: '1.0.0' } },
+    queryParams: [
+      { name: 'index', type: 'string', description: 'Index pattern to search' },
+      { name: 'keep_alive', type: 'string', description: 'The interval to keep the results alive' },
+      {
+        name: 'keep_on_completion',
+        type: 'boolean',
+        description: 'If true, save results in the cluster after search completes',
+      },
+      {
+        name: 'wait_for_completion_timeout',
+        type: 'string',
+        description: 'Time to wait for request completion',
+      },
+    ],
   },
   {
     path: '/_plugins/_asynchronous_search/{id}',
@@ -1420,12 +2785,23 @@ export class ApiSpecProvider {
   ): ApiEndpoint | undefined {
     const endpoints = this.getEndpoints(backend, version);
 
-    return endpoints.find(endpoint => {
+    const matches = endpoints.filter(endpoint => {
       if (method && !endpoint.methods.includes(method)) {
         return false;
       }
       return this.matchPath(endpoint.path, path);
     });
+
+    return matches.sort((a, b) => this.pathSpecificity(b.path) - this.pathSpecificity(a.path))[0];
+  }
+
+  private pathSpecificity(pattern: string): number {
+    return pattern
+      .split('/')
+      .filter(Boolean)
+      .reduce((score, part) => {
+        return score + (part.startsWith('{') && part.endsWith('}') ? 0 : 1);
+      }, 0);
   }
 
   /**

--- a/src/common/monaco/searchdsl/completionProvider.ts
+++ b/src/common/monaco/searchdsl/completionProvider.ts
@@ -418,8 +418,14 @@ const providePathCompletions = (
     const indexName = indexWithSlashMatch ? indexWithSlashMatch[1] : indexWithPartialEndpoint?.[1];
     const partialEndpoint = indexWithPartialEndpoint ? indexWithPartialEndpoint[2] : '';
 
-    // Provide index-specific endpoints
-    const indexEndpoints = getIndexSpecificEndpoints();
+    const indexEndpoints = endpoints
+      .filter(e => /^\/{index}\//.test(e.path) || e.path === '/{index}')
+      .map(e => ({
+        path: e.path.replace(/^\/\{index\}\//, '').replace(/^\/\{index\}$/, ''),
+        methods: e.methods,
+        description: e.description,
+      }))
+      .filter(e => e.path.length > 0);
     for (const ep of indexEndpoints) {
       // Filter by partial endpoint if typed
       if (partialEndpoint && !ep.path.toLowerCase().startsWith(partialEndpoint.toLowerCase())) {
@@ -442,12 +448,13 @@ const providePathCompletions = (
       const sortPrefix = ep.path.includes('_search') ? '0' : '1';
 
       completions.push({
-        label: fullPath,
+        label: ep.path,
         kind: monaco.languages.CompletionItemKind.Function,
         insertText: fullPath,
+        filterText: fullPath,
         insertTextRules: monaco.languages.CompletionItemInsertTextRule.None,
         detail: ep.description,
-        sortText: sortPrefix + fullPath,
+        sortText: sortPrefix + ep.path,
         range,
       });
     }
@@ -494,6 +501,10 @@ const providePathCompletions = (
       if (!pathStartsWithPattern('/' + normalizedEndpointPath, '/' + normalizedUserPath)) {
         continue;
       }
+
+      if (isExactPathMatch('/' + normalizedEndpointPath, '/' + normalizedUserPath)) {
+        continue;
+      }
     }
 
     // Determine the label and insert text based on user's slash preference
@@ -538,61 +549,6 @@ const providePathCompletions = (
   return completions;
 };
 
-/**
- * Get index-specific endpoints for completion after an index name
- */
-const getIndexSpecificEndpoints = (): Array<{
-  path: string;
-  methods: HttpMethod[];
-  description: string;
-}> => {
-  return [
-    { path: '_search', methods: ['GET', 'POST'], description: 'Search documents' },
-    { path: '_count', methods: ['GET', 'POST'], description: 'Count documents' },
-    { path: '_doc', methods: ['POST'], description: 'Index a document' },
-    {
-      path: '_doc/{id}',
-      methods: ['GET', 'PUT', 'DELETE'],
-      description: 'Get/index/delete document by ID',
-    },
-    { path: '_update/{id}', methods: ['POST'], description: 'Update document' },
-    { path: '_bulk', methods: ['POST'], description: 'Bulk operations' },
-    { path: '_mapping', methods: ['GET', 'PUT'], description: 'Index mappings' },
-    { path: '_settings', methods: ['GET', 'PUT'], description: 'Index settings' },
-    { path: '_refresh', methods: ['POST'], description: 'Refresh index' },
-    { path: '_flush', methods: ['POST'], description: 'Flush index' },
-    { path: '_forcemerge', methods: ['POST'], description: 'Force merge' },
-    { path: '_open', methods: ['POST'], description: 'Open index' },
-    { path: '_close', methods: ['POST'], description: 'Close index' },
-    {
-      path: '_alias/{alias}',
-      methods: ['GET', 'PUT', 'DELETE', 'HEAD'],
-      description: 'Index alias',
-    },
-    {
-      path: '_alias',
-      methods: ['GET'],
-      description: 'Get index aliases',
-    },
-    { path: '_analyze', methods: ['GET', 'POST'], description: 'Analyze text' },
-    { path: '_validate/query', methods: ['GET', 'POST'], description: 'Validate query' },
-    { path: '_msearch', methods: ['GET', 'POST'], description: 'Multi search' },
-    { path: '_explain/{id}', methods: ['GET', 'POST'], description: 'Explain scoring' },
-    { path: '_terms_enum', methods: ['GET', 'POST'], description: 'Terms enumeration' },
-    { path: '_update_by_query', methods: ['POST'], description: 'Update by query' },
-    { path: '_delete_by_query', methods: ['POST'], description: 'Delete by query' },
-    { path: '_cache/clear', methods: ['POST'], description: 'Clear cache' },
-    { path: '_recovery', methods: ['GET'], description: 'Recovery status' },
-    { path: '_segments', methods: ['GET'], description: 'Index segments' },
-    { path: '_stats', methods: ['GET'], description: 'Index stats' },
-    { path: '_search_shards', methods: ['GET', 'POST'], description: 'Search shards' },
-    { path: '_field_caps', methods: ['GET', 'POST'], description: 'Field capabilities' },
-  ];
-};
-
-/**
- * Check if a path pattern starts with a prefix (handling placeholders)
- */
 const pathStartsWithPattern = (pattern: string, prefix: string): boolean => {
   const patternParts = pattern.split('/').filter(Boolean);
   const prefixParts = prefix.split('/').filter(Boolean);
@@ -613,6 +569,18 @@ const pathStartsWithPattern = (pattern: string, prefix: string): boolean => {
     }
 
     return patternPart === prefixPart;
+  });
+};
+
+const isExactPathMatch = (pattern: string, path: string): boolean => {
+  const patternParts = pattern.split('/').filter(Boolean);
+  const pathParts = path.split('/').filter(Boolean);
+
+  if (patternParts.length !== pathParts.length) return false;
+
+  return patternParts.every((patternPart, i) => {
+    if (patternPart.startsWith('{') && patternPart.endsWith('}')) return true;
+    return patternPart.toLowerCase() === pathParts[i].toLowerCase();
   });
 };
 

--- a/src/common/monaco/searchdsl/completionProvider.ts
+++ b/src/common/monaco/searchdsl/completionProvider.ts
@@ -411,8 +411,10 @@ const providePathCompletions = (
   const indexWithSlashMatch = /^([^/]+)\/$/.exec(normalizedUserPath);
   const indexWithPartialEndpoint = /^([^/]+)\/(_[^/]*)$/.exec(normalizedUserPath);
 
-  // If user has typed an index name followed by slash, suggest endpoints
-  if (indexWithSlashMatch || indexWithPartialEndpoint) {
+  const firstSegment = indexWithSlashMatch?.[1] ?? indexWithPartialEndpoint?.[1];
+  const isRootVerb = firstSegment?.startsWith('_') ?? false;
+
+  if ((indexWithSlashMatch || indexWithPartialEndpoint) && !isRootVerb) {
     const indexName = indexWithSlashMatch ? indexWithSlashMatch[1] : indexWithPartialEndpoint?.[1];
     const partialEndpoint = indexWithPartialEndpoint ? indexWithPartialEndpoint[2] : '';
 
@@ -454,12 +456,14 @@ const providePathCompletions = (
   // Add index name completions from dynamic options
   // Only show when user is typing something that could be an index name (not starting with _)
   const isTypingIndexName =
-    normalizedUserPath && !normalizedUserPath.startsWith('_') && !normalizedUserPath.includes('/');
+    !normalizedUserPath.startsWith('_') && !normalizedUserPath.includes('/');
 
   if (isTypingIndexName && dynamicOptions.indices && dynamicOptions.indices.length > 0) {
     for (const indexName of dynamicOptions.indices) {
-      // Filter by what user typed
-      if (!indexName.toLowerCase().startsWith(normalizedUserPath.toLowerCase())) {
+      if (
+        normalizedUserPath &&
+        !indexName.toLowerCase().startsWith(normalizedUserPath.toLowerCase())
+      ) {
         continue;
       }
 
@@ -758,7 +762,8 @@ const provideBodyCompletions = (
       });
     }
   } else if (bodyPath[0] === 'mappings' || bodyPath[0] === 'properties') {
-    if (bodyPath[0] === 'properties' || bodyPath.includes('properties')) {
+    const lastSegment = bodyPath[bodyPath.length - 1];
+    if (lastSegment === 'properties') {
       const fieldTypes = getFieldTypeOptions();
       for (const fieldType of fieldTypes) {
         completions.push({

--- a/src/common/monaco/searchdsl/completionProvider.ts
+++ b/src/common/monaco/searchdsl/completionProvider.ts
@@ -762,8 +762,8 @@ const provideBodyCompletions = (
       });
     }
   } else if (bodyPath[0] === 'mappings' || bodyPath[0] === 'properties') {
-    const lastSegment = bodyPath[bodyPath.length - 1];
-    if (lastSegment === 'properties') {
+    if (bodyPath.includes('properties')) {
+      // Inside a properties block at any level — provide field type completions
       const fieldTypes = getFieldTypeOptions();
       for (const fieldType of fieldTypes) {
         completions.push({

--- a/src/common/monaco/searchdsl/completionProvider.ts
+++ b/src/common/monaco/searchdsl/completionProvider.ts
@@ -762,8 +762,8 @@ const provideBodyCompletions = (
       });
     }
   } else if (bodyPath[0] === 'mappings' || bodyPath[0] === 'properties') {
-    if (bodyPath.includes('properties')) {
-      // Inside a properties block at any level — provide field type completions
+    const lastSegment = bodyPath[bodyPath.length - 1];
+    if (lastSegment === 'properties' || lastSegment === 'fields') {
       const fieldTypes = getFieldTypeOptions();
       for (const fieldType of fieldTypes) {
         completions.push({

--- a/src/views/editor/es-editor/display-editor.vue
+++ b/src/views/editor/es-editor/display-editor.vue
@@ -49,18 +49,24 @@ watch(
   { deep: true },
 );
 
-const display = (content: unknown) => {
+const resolveLanguage = (content: unknown, format?: string): string => {
+  if (format === 'yaml') return 'yaml';
+  if (typeof content === 'object') return 'json';
+  return 'plaintext';
+};
+
+const display = (content: unknown, format?: string) => {
   const model = displayEditor?.getModel();
   if (!model) {
     return;
   }
-  const type = typeof content === 'object' ? 'json' : 'plain/text';
+  const language = resolveLanguage(content, format);
   const indent = editorConfig.value.insertSpaces ? ' '.repeat(editorConfig.value.tabSize) : '\t';
 
   const formattedContent =
-    type === 'json' ? jsonify.stringify(content, null, indent) : (content ?? '').toString();
+    language === 'json' ? jsonify.stringify(content, null, indent) : (content ?? '').toString();
 
-  monaco.editor.setModelLanguage(model, type);
+  monaco.editor.setModelLanguage(model, language);
 
   model.setValue(formattedContent);
 };

--- a/src/views/editor/es-editor/index.vue
+++ b/src/views/editor/es-editor/index.vue
@@ -215,7 +215,8 @@ const executeQueryAction = async (position: { column: number; lineNumber: number
       connectionId: activeConnection.value.id,
     });
 
-    showDisplayEditor(data);
+    const format = new URLSearchParams(action.queryParams ?? '').get('format') ?? undefined;
+    showDisplayEditor(data, format);
     loadingBar.finish();
   } catch (err) {
     loadingBar.error();
@@ -530,9 +531,9 @@ const setupQueryEditor = () => {
 
 const queryEditorSize = ref(1);
 
-const showDisplayEditor = (content: unknown) => {
+const showDisplayEditor = (content: unknown, format?: string) => {
   queryEditorSize.value = queryEditorSize.value === 1 ? 0.5 : queryEditorSize.value;
-  displayRef.value.display(content);
+  displayRef.value.display(content, format);
 };
 
 const saveFileListener = ref<Function>();

--- a/tests/common/monaco/searchdsl/apiSpecCompliance.test.ts
+++ b/tests/common/monaco/searchdsl/apiSpecCompliance.test.ts
@@ -1,0 +1,369 @@
+import * as monaco from 'monaco-editor';
+import {
+  grammarCompletionProvider,
+  setCompletionConfig,
+  setDynamicOptions,
+  BackendType,
+} from '../../../../src/common/monaco/searchdsl/completionProvider';
+import { apiSpecProvider } from '../../../../src/common/monaco/searchdsl/apiSpec';
+
+jest.mock('monaco-editor', () => ({
+  Range: class Range {
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+    constructor(
+      startLineNumber: number,
+      startColumn: number,
+      endLineNumber: number,
+      endColumn: number,
+    ) {
+      this.startLineNumber = startLineNumber;
+      this.startColumn = startColumn;
+      this.endLineNumber = endLineNumber;
+      this.endColumn = endColumn;
+    }
+  },
+  languages: {
+    CompletionItemKind: { Keyword: 17, Function: 1, Property: 9, Class: 5, Value: 12 },
+    CompletionItemInsertTextRule: { None: 0, InsertAsSnippet: 4 },
+  },
+}));
+
+const createMockModel = (text: string): monaco.editor.ITextModel => {
+  const lines = text.split('\n');
+  return {
+    getValue: () => text,
+    getLineContent: (lineNumber: number) => lines[lineNumber - 1] || '',
+    getOffsetAt: (pos: { lineNumber: number; column: number }) => {
+      let offset = 0;
+      for (let i = 0; i < pos.lineNumber - 1; i++) offset += lines[i].length + 1;
+      return offset + pos.column - 1;
+    },
+    getWordUntilPosition: (pos: { lineNumber: number; column: number }) => {
+      const line = lines[pos.lineNumber - 1] || '';
+      const before = line.substring(0, pos.column - 1);
+      const match = before.match(/[a-zA-Z_][a-zA-Z0-9_]*$/);
+      return match
+        ? { word: match[0], startColumn: pos.column - match[0].length, endColumn: pos.column }
+        : { word: '', startColumn: pos.column, endColumn: pos.column };
+    },
+  } as monaco.editor.ITextModel;
+};
+
+const suggestionsFor = (text: string) => {
+  const model = createMockModel(text);
+  const position = { lineNumber: 1, column: text.length + 1 };
+  return grammarCompletionProvider(model, position as monaco.Position).suggestions;
+};
+
+const labelsFor = (text: string) => suggestionsFor(text).map(s => s.label);
+
+const concretePath = (pattern: string): string =>
+  pattern
+    .replace(/\{index\}/g, 'my_index')
+    .replace(/\{id\}/g, '1')
+    .replace(/\{alias\}/g, 'my_alias')
+    .replace(/\{template\}/g, 'my_template')
+    .replace(/\{repository\}/g, 'my_repo')
+    .replace(/\{snapshot\}/g, 'my_snapshot')
+    .replace(/\{task_id\}/g, 'abc123')
+    .replace(/\{pipeline\}/g, 'my_pipeline')
+    .replace(/\{transform_id\}/g, 'my_transform')
+    .replace(/\{data_stream\}/g, 'my_stream')
+    .replace(/\{policy\}/g, 'my_policy')
+    .replace(/\{job_id\}/g, 'my_job')
+    .replace(/\{watch_id\}/g, 'my_watch')
+    .replace(/\{job_id\}/g, 'my_job')
+    .replace(/\{model_id\}/g, 'my_model')
+    .replace(/\{username\}/g, 'admin')
+    .replace(/\{role\}/g, 'my_role')
+    .replace(/\{detector_id\}/g, 'det1')
+    .replace(/\{monitor_id\}/g, 'mon1')
+    .replace(/\{channel_id\}/g, 'chan1')
+    .replace(/\{[^}]+\}/g, 'fixture_value');
+
+const assertQueryParamCompletions = (
+  backend: BackendType,
+  version: string,
+  method: string,
+  path: string,
+) => {
+  const endpoint = apiSpecProvider.findEndpoint(backend, path, method as never, version);
+  if (!endpoint?.queryParams?.length) return;
+
+  const text = `${method} ${path}?`;
+
+  it(`${method} ${path} — param names`, () => {
+    const labels = labelsFor(text);
+    endpoint.queryParams!.forEach(p => {
+      expect(labels).toContain(p.name);
+    });
+  });
+
+  endpoint
+    .queryParams!.filter(p => p.enum?.length)
+    .forEach(p => {
+      it(`${method} ${path} — ${p.name} enum values`, () => {
+        const valueText = `${text}${p.name}=`;
+        const labels = labelsFor(valueText);
+        p.enum!.forEach(v => expect(labels).toContain(v));
+      });
+    });
+
+  endpoint
+    .queryParams!.filter(p => p.type === 'boolean')
+    .forEach(p => {
+      it(`${method} ${path} — ${p.name} boolean values`, () => {
+        const valueText = `${text}${p.name}=`;
+        const labels = labelsFor(valueText);
+        expect(labels).toContain('true');
+        expect(labels).toContain('false');
+      });
+    });
+};
+
+describe('apiSpec compliance — common endpoints (Elasticsearch)', () => {
+  beforeEach(() => {
+    setCompletionConfig({ backend: BackendType.ELASTICSEARCH, version: '8.0.0' });
+    setDynamicOptions({ indices: ['my_index'], activeIndex: 'my_index' });
+  });
+
+  const esVersion = '8.0.0';
+
+  const commonCases: Array<[string, string]> = [
+    ['GET', '/_search'],
+    ['GET', '/my_index/_search'],
+    ['GET', '/_count'],
+    ['GET', '/my_index/_count'],
+    ['POST', '/my_index/_doc'],
+    ['GET', '/my_index/_doc/1'],
+    ['POST', '/_bulk'],
+    ['POST', '/my_index/_bulk'],
+    ['GET', '/my_index/_mapping'],
+    ['GET', '/my_index/_settings'],
+    ['POST', '/my_index/_open'],
+    ['POST', '/my_index/_close'],
+    ['POST', '/my_index/_refresh'],
+    ['POST', '/my_index/_flush'],
+    ['POST', '/my_index/_forcemerge'],
+    ['PUT', '/my_index/_alias/my_alias'],
+    ['GET', '/_cat/indices'],
+    ['GET', '/_cat/health'],
+    ['GET', '/_cat/nodes'],
+    ['GET', '/_cat/shards'],
+    ['GET', '/_cat/aliases'],
+    ['GET', '/_cat/templates'],
+    ['GET', '/_cat/allocation'],
+    ['GET', '/_cluster/health'],
+    ['GET', '/_cluster/state'],
+    ['GET', '/_cluster/stats'],
+    ['GET', '/_cluster/settings'],
+    ['POST', '/_cluster/allocation/explain'],
+    ['POST', '/_cluster/reroute'],
+    ['GET', '/_nodes'],
+    ['GET', '/_nodes/stats'],
+    ['GET', '/_nodes/hot_threads'],
+    ['GET', '/_template/my_template'],
+    ['GET', '/_index_template/my_template'],
+    ['GET', '/_component_template/my_template'],
+    ['GET', '/my_index/_analyze'],
+    ['GET', '/my_index/_validate/query'],
+    ['GET', '/_msearch'],
+    ['GET', '/my_index/_msearch'],
+    ['GET', '/my_index/_explain/1'],
+    ['POST', '/_reindex'],
+    ['POST', '/my_index/_update_by_query'],
+    ['POST', '/my_index/_delete_by_query'],
+    ['GET', '/_snapshot'],
+    ['GET', '/_snapshot/my_repo'],
+    ['GET', '/_snapshot/my_repo/my_snapshot'],
+    ['POST', '/_snapshot/my_repo/my_snapshot/_restore'],
+    ['GET', '/_tasks'],
+    ['GET', '/_tasks/abc123'],
+    ['POST', '/_tasks/abc123/_cancel'],
+    ['GET', '/_ingest/pipeline'],
+    ['GET', '/_ingest/pipeline/my_pipeline'],
+    ['POST', '/_ingest/pipeline/_simulate'],
+    ['GET', '/_scripts/my_id'],
+    ['GET', '/_field_caps'],
+    ['GET', '/my_index/_field_caps'],
+    ['GET', '/_search/scroll'],
+    ['POST', '/_cache/clear'],
+    ['POST', '/my_index/_cache/clear'],
+    ['GET', '/my_index/_recovery'],
+    ['GET', '/my_index/_segments'],
+    ['GET', '/_stats'],
+    ['GET', '/my_index/_stats'],
+    ['GET', '/my_index/_search_shards'],
+  ];
+
+  commonCases.forEach(([method, path]) => {
+    assertQueryParamCompletions(BackendType.ELASTICSEARCH, esVersion, method, path);
+  });
+});
+
+describe('apiSpec compliance — Elasticsearch-only endpoints', () => {
+  beforeEach(() => {
+    setCompletionConfig({ backend: BackendType.ELASTICSEARCH, version: '8.0.0' });
+    setDynamicOptions({ indices: ['my_index'], activeIndex: 'my_index' });
+  });
+
+  const esVersion = '8.0.0';
+
+  const esCases: Array<[string, string]> = [
+    ['GET', '/my_index/_eql/search'],
+    ['GET', '/_sql'],
+    ['GET', '/_transform'],
+    ['GET', '/_transform/my_transform'],
+    ['GET', '/_data_stream'],
+    ['GET', '/_data_stream/my_stream'],
+    ['GET', '/_ilm/policy'],
+    ['GET', '/_ilm/policy/my_policy'],
+    ['GET', '/_rollup/job/my_job'],
+    ['GET', '/_watcher/watch/my_watch'],
+    ['GET', '/_ml/anomaly_detectors'],
+    ['GET', '/_ml/anomaly_detectors/my_job'],
+    ['GET', '/_ml/trained_models'],
+    ['GET', '/_ml/trained_models/my_model'],
+    ['POST', '/_ml/trained_models/my_model/_infer'],
+    ['GET', '/_security/user'],
+    ['GET', '/_security/user/admin'],
+    ['GET', '/_security/role/my_role'],
+    ['GET', '/_security/api_key'],
+  ];
+
+  esCases.forEach(([method, path]) => {
+    assertQueryParamCompletions(BackendType.ELASTICSEARCH, esVersion, method, path);
+  });
+});
+
+describe('apiSpec compliance — OpenSearch-only endpoints', () => {
+  beforeEach(() => {
+    setCompletionConfig({ backend: BackendType.OPENSEARCH, version: '2.0.0' });
+    setDynamicOptions({ indices: ['my_index'], activeIndex: 'my_index' });
+  });
+
+  const osVersion = '2.0.0';
+
+  const osCases: Array<[string, string]> = [
+    ['GET', '/_plugins/_anomaly_detection/detectors'],
+    ['GET', '/_plugins/_anomaly_detection/detectors/det1'],
+    ['GET', '/_plugins/_alerting/monitors'],
+    ['GET', '/_plugins/_alerting/monitors/mon1'],
+    ['GET', '/_plugins/_ism/policies'],
+    ['GET', '/_plugins/_ism/policies/my_policy'],
+    ['POST', '/_plugins/_asynchronous_search'],
+  ];
+
+  osCases.forEach(([method, path]) => {
+    assertQueryParamCompletions(BackendType.OPENSEARCH, osVersion, method, path);
+  });
+});
+
+describe('apiSpec compliance — path completions', () => {
+  beforeEach(() => {
+    setCompletionConfig({ backend: BackendType.ELASTICSEARCH, version: '8.0.0' });
+    setDynamicOptions({ indices: ['my_index', 'logs-2024'], activeIndex: 'my_index' });
+  });
+
+  it('offers _search after index prefix', () => {
+    expect(labelsFor('GET my_index/')).toContain('_search');
+  });
+
+  it('offers _count after index prefix', () => {
+    expect(labelsFor('GET my_index/')).toContain('_count');
+  });
+
+  it('offers _bulk after index prefix', () => {
+    expect(labelsFor('POST my_index/')).toContain('_bulk');
+  });
+
+  it('offers _mapping after index prefix', () => {
+    expect(labelsFor('GET my_index/')).toContain('_mapping');
+  });
+
+  it('offers root paths starting with _', () => {
+    const labels = labelsFor('GET /_');
+    expect(labels.some(l => l.startsWith('/_') || l.startsWith('_'))).toBe(true);
+  });
+
+  it('suppresses path completions when path is already complete', () => {
+    const labels = labelsFor('GET my_index/_search');
+    expect(labels).not.toContain('my_index/_search');
+  });
+
+  it('suppresses path completions when exact deep path is complete', () => {
+    const labels = labelsFor('POST my_index/_eql/search');
+    expect(labels).not.toContain('my_index/_eql/search');
+  });
+});
+
+describe('apiSpec compliance — backend isolation', () => {
+  it('does not return ES-only endpoints on OpenSearch connection', () => {
+    setCompletionConfig({ backend: BackendType.OPENSEARCH, version: '2.0.0' });
+    setDynamicOptions({});
+    const labels = labelsFor('GET /_');
+    expect(labels).not.toContain('/_eql');
+    expect(labels).not.toContain('/_transform');
+    expect(labels).not.toContain('/_rollup');
+  });
+
+  it('does not return OpenSearch plugin paths on Elasticsearch connection', () => {
+    setCompletionConfig({ backend: BackendType.ELASTICSEARCH, version: '8.0.0' });
+    setDynamicOptions({});
+    const allLabels = labelsFor('GET /');
+    expect(allLabels.some(l => l.includes('_plugins/_anomaly_detection'))).toBe(false);
+    expect(allLabels.some(l => l.includes('_plugins/_alerting'))).toBe(false);
+    expect(allLabels.some(l => l.includes('_plugins/_ism'))).toBe(false);
+  });
+
+  it('index-scoped completions on ES do not include OpenSearch-only endpoints', () => {
+    setCompletionConfig({ backend: BackendType.ELASTICSEARCH, version: '8.0.0' });
+    setDynamicOptions({ indices: ['my_index'], activeIndex: 'my_index' });
+    const labels = labelsFor('GET my_index/');
+    expect(labels.some(l => l.includes('_plugins'))).toBe(false);
+  });
+
+  it('index-scoped completions on OpenSearch include _eql when available', () => {
+    setCompletionConfig({ backend: BackendType.ELASTICSEARCH, version: '8.0.0' });
+    setDynamicOptions({ indices: ['my_index'], activeIndex: 'my_index' });
+    const labels = labelsFor('GET my_index/');
+    expect(labels).toContain('_eql/search');
+  });
+
+  it('returns common endpoints on both backends', () => {
+    setCompletionConfig({ backend: BackendType.ELASTICSEARCH, version: '8.0.0' });
+    setDynamicOptions({});
+    const esLabels = labelsFor('GET /_');
+
+    setCompletionConfig({ backend: BackendType.OPENSEARCH, version: '2.0.0' });
+    const osLabels = labelsFor('GET /_');
+
+    expect(esLabels).toContain('/_search');
+    expect(osLabels).toContain('/_search');
+    expect(esLabels).toContain('/_cat/indices');
+    expect(osLabels).toContain('/_cat/indices');
+  });
+});
+
+describe('apiSpec compliance — already-typed param exclusion', () => {
+  beforeEach(() => {
+    setCompletionConfig({ backend: BackendType.ELASTICSEARCH, version: '8.0.0' });
+    setDynamicOptions({});
+  });
+
+  it('excludes already-typed param from subsequent suggestions', () => {
+    const labels = labelsFor('GET /_search?size=10&');
+    expect(labels).not.toContain('size');
+    expect(labels).toContain('from');
+  });
+
+  it('excludes multiple already-typed params', () => {
+    const labels = labelsFor('GET /_search?size=10&from=0&');
+    expect(labels).not.toContain('size');
+    expect(labels).not.toContain('from');
+    expect(labels).toContain('q');
+  });
+});

--- a/tests/common/monaco/searchdsl/completionProvider.test.ts
+++ b/tests/common/monaco/searchdsl/completionProvider.test.ts
@@ -954,7 +954,7 @@ describe('grammarCompletionProvider', () => {
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
       const labels = result.suggestions.map(s => s.label);
-      expect(labels).toContain('my_index/_alias');
+      expect(labels).toContain('_alias');
     });
 
     it('should suggest _alias/{alias} when typing GET my_index/_', () => {
@@ -965,8 +965,12 @@ describe('grammarCompletionProvider', () => {
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
       const labels = result.suggestions.map(s => s.label);
-      expect(labels).toContain('my_index/_alias');
-      expect(labels).toContain('my_index/_alias/{alias}');
+      expect(labels).toContain('_alias');
+      expect(labels).toContain('_alias/{alias}');
+
+      const aliasItem = result.suggestions.find(s => s.label === '_alias');
+      expect(aliasItem?.filterText).toBe('my_index/_alias');
+      expect(aliasItem?.insertText).toBe('my_index/_alias');
     });
   });
 
@@ -1026,7 +1030,10 @@ describe('grammarCompletionProvider', () => {
       const labels = result.suggestions.map(s => s.label);
       expect(labels).toContain('text');
       expect(labels).toContain('json');
-      expect(labels).toHaveLength(2);
+      expect(labels).toContain('yaml');
+      expect(labels).toContain('cbor');
+      expect(labels).toContain('smile');
+      expect(labels).toHaveLength(5);
     });
 
     it('should show boolean value completions when cursor is right after = on boolean param', () => {
@@ -1297,6 +1304,73 @@ describe('grammarCompletionProvider', () => {
       const labels = result.suggestions.map(s => s.label);
       expect(labels).toContain('max_concurrent_searches');
       expect(labels).toContain('search_type');
+    });
+  });
+
+  describe('_stats query parameters', () => {
+    it('should provide query params for GET /_stats?', () => {
+      const text = `GET /_stats?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('fields');
+      expect(labels).toContain('level');
+      expect(labels).toContain('include_unloaded_segments');
+    });
+
+    it('should provide query params for GET {index}/_stats?', () => {
+      const text = `GET my_index/_stats?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('fields');
+      expect(labels).toContain('level');
+    });
+  });
+
+  describe('_data_stream query parameters', () => {
+    it('should provide query params for GET /_data_stream?', () => {
+      const text = `GET /_data_stream?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('expand_wildcards');
+      expect(labels).toContain('master_timeout');
+    });
+  });
+
+  describe('_eql search path completions', () => {
+    it('should NOT show path completions when exact path already typed', () => {
+      const text = `POST my_index/_eql/search`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('_eql/search');
+      expect(labels).not.toContain('my_index/_eql/search');
+    });
+
+    it('should show query params after ? on _eql/search', () => {
+      const text = `POST my_index/_eql/search?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('keep_alive');
+      expect(labels).toContain('wait_for_completion_timeout');
     });
   });
 });

--- a/tests/common/monaco/searchdsl/completionProvider.test.ts
+++ b/tests/common/monaco/searchdsl/completionProvider.test.ts
@@ -498,12 +498,29 @@ describe('grammarCompletionProvider', () => {
 
       const text = `GET test_`;
       const model = createMockModel(text);
-      const position = { lineNumber: 1, column: 10 }; // After 'test_'
+      const position = { lineNumber: 1, column: 10 };
 
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
       const labels = result.suggestions.map(s => s.label);
       expect(labels).toContain('test_index');
+    });
+
+    it('should provide index names immediately after HTTP method', () => {
+      setDynamicOptions({
+        indices: ['test_index', 'logs_index', 'metrics_index'],
+      });
+
+      const text = `GET `;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: 5 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('test_index');
+      expect(labels).toContain('logs_index');
+      expect(labels).toContain('metrics_index');
     });
 
     it('should not provide index names when path starts with _', () => {
@@ -513,7 +530,7 @@ describe('grammarCompletionProvider', () => {
 
       const text = `GET _cat`;
       const model = createMockModel(text);
-      const position = { lineNumber: 1, column: 9 }; // After '_cat'
+      const position = { lineNumber: 1, column: 9 };
 
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
@@ -527,14 +544,40 @@ describe('grammarCompletionProvider', () => {
     it('should provide endpoints after index name with slash', () => {
       const text = `GET test_index/`;
       const model = createMockModel(text);
-      const position = { lineNumber: 1, column: 16 }; // After '/'
+      const position = { lineNumber: 1, column: 16 };
 
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
       const labels = result.suggestions.map(s => s.label);
-      // Should contain index-specific endpoints
       const searchPath = labels.find(l => typeof l === 'string' && l.includes('_search'));
       expect(searchPath).toBeDefined();
+    });
+
+    it('should NOT provide index sub-verbs after root verb like _cluster/', () => {
+      const text = `GET _cluster/`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: 14 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('_search');
+      expect(labels).not.toContain('_mapping');
+      expect(labels).not.toContain('_settings');
+      expect(labels.some(l => typeof l === 'string' && l.includes('_cluster/'))).toBe(true);
+    });
+
+    it('should NOT provide index sub-verbs after root verb like _cat/', () => {
+      const text = `GET _cat/`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: 10 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('_search');
+      expect(labels).not.toContain('_mapping');
+      expect(labels.some(l => typeof l === 'string' && l.includes('_cat/'))).toBe(true);
     });
 
     it('should prioritize _search endpoints in path completions', () => {
@@ -661,7 +704,26 @@ describe('grammarCompletionProvider', () => {
   });
 
   describe('nested properties in mappings', () => {
-    it('should provide field types inside properties block', () => {
+    it('should provide field types directly inside properties block', () => {
+      const text = `PUT test_index/_mapping
+{
+  properties: {
+    
+  }
+}`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 4, column: 5 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('text');
+      expect(labels).toContain('keyword');
+      expect(labels).toContain('object');
+      expect(labels).toContain('nested');
+    });
+
+    it('should NOT provide field type snippets inside field definition object', () => {
       const text = `PUT test_index/_mapping
 {
   properties: {
@@ -676,11 +738,11 @@ describe('grammarCompletionProvider', () => {
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
       const labels = result.suggestions.map(s => s.label);
-      expect(labels).toContain('text');
-      expect(labels).toContain('keyword');
+      expect(labels).not.toContain('text');
+      expect(labels).not.toContain('keyword');
     });
 
-    it('should provide field types inside deeply nested properties', () => {
+    it('should NOT provide field type snippets inside deeply nested field definition', () => {
       const text = `PUT test_index/_mapping
 {
   properties: {
@@ -700,7 +762,55 @@ describe('grammarCompletionProvider', () => {
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
       const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('text');
+      expect(labels).not.toContain('keyword');
+    });
+
+    it('should provide field types directly inside nested object properties', () => {
+      const text = `PUT test_index/_mapping
+{
+  properties: {
+    author: {
+      type: "object",
+      properties: {
+        
+      }
+    }
+  }
+}`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 7, column: 7 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
       expect(labels).toContain('text');
+      expect(labels).toContain('keyword');
+    });
+
+    it('should provide field types directly inside fields subfield properties', () => {
+      const text = `PUT test_index/_mapping
+{
+  properties: {
+    title: {
+      type: "text",
+      fields: {
+        keyword: {
+          type: "keyword"
+        },
+        
+      }
+    }
+  }
+}`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 10, column: 7 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('text');
+      expect(labels).toContain('keyword');
     });
   });
 
@@ -1125,6 +1235,68 @@ describe('grammarCompletionProvider', () => {
       expect(labels).toContain('red');
       expect(labels).not.toContain('v');
       expect(labels).not.toContain('health');
+    });
+  });
+
+  describe('_mapping query parameters', () => {
+    it('should provide query params for _mapping endpoint', () => {
+      const text = `GET my_index/_mapping?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('allow_no_indices');
+      expect(labels).toContain('expand_wildcards');
+      expect(labels).toContain('ignore_unavailable');
+      expect(labels).toContain('timeout');
+    });
+
+    it('should provide enum values for expand_wildcards on _mapping', () => {
+      const text = `GET my_index/_mapping?expand_wildcards=`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('open');
+      expect(labels).toContain('closed');
+      expect(labels).toContain('hidden');
+      expect(labels).toContain('none');
+      expect(labels).toContain('all');
+    });
+  });
+
+  describe('_settings query parameters', () => {
+    it('should provide query params for _settings endpoint', () => {
+      const text = `GET my_index/_settings?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('allow_no_indices');
+      expect(labels).toContain('expand_wildcards');
+      expect(labels).toContain('flat_settings');
+      expect(labels).toContain('include_defaults');
+      expect(labels).toContain('timeout');
+    });
+  });
+
+  describe('_msearch query parameters', () => {
+    it('should provide query params for _msearch with index', () => {
+      const text = `GET my_index/_msearch?`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 1, column: text.length + 1 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).toContain('max_concurrent_searches');
+      expect(labels).toContain('search_type');
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR addresses multiple auto-completion and response display issues in the Connect Console:

### Auto-completion Fixes

- **#386**: Field type snippets were incorrectly suggested at any depth inside `properties` objects. Now they only appear when the cursor is directly inside a `properties` block.

- **#383**: Index sub-verb suggestions (`_search`, `_mapping`, etc.) were incorrectly shown after Elasticsearch root verbs like `GET _cluster/`. Added a guard to detect `_`-prefixed segments as root verbs.

- **#382**: Indices were not shown immediately after typing an HTTP method (e.g., `GET ` with empty path). Now indices are displayed alongside root API verbs.

- **#384**: Query parameter completions were missing for `_mapping`, `_settings`, and `_msearch` endpoints. Added comprehensive `queryParams` arrays based on elasticsearch-specification.

- **Spec Gaps**: 
  - `format` enum on all `/_cat/*` endpoints corrected from `['text', 'json']` → `['text', 'json', 'yaml', 'cbor', 'smile']`
  - Added `include_defaults: boolean` to `/{index}/_mapping` queryParams
  - Added missing `/{index}/_alias` endpoint for bare alias listing

- **Backend Isolation**: Replaced hardcoded `getIndexSpecificEndpoints()` static list with live backend-aware derivation from `apiSpecProvider.getEndpoints(backend, version)` — now automatically respects backend/version filtering.

### Response Display Enhancement

- **YAML Syntax Highlighting**: Responses with `format=yaml` query parameter now display with proper YAML syntax highlighting in Monaco editor. Previously only JSON responses were highlighted.

## Changes

**`completionProvider.ts`**:
- Changed `bodyPath.includes('properties')` to `lastSegment === 'properties'` for precise context detection
- Added `isRootVerb` guard to suppress index sub-verbs after `_`-prefixed paths
- Removed truthy guard from `isTypingIndexName` to show indices on empty path
- Deleted hardcoded `getIndexSpecificEndpoints()` — replaced with live backend-aware derivation

**`apiSpec.ts`**:
- Added 6 query params to `/{index}/_mapping`
- Added 8 query params to `/{index}/_settings`
- Added 6 query params to `/_msearch` and `/{index}/_msearch`
- Fixed `format` enum on all 7 `/_cat/*` endpoints
- Added `include_defaults` to `/{index}/_mapping`
- Added `/{index}/_alias` endpoint

**`display-editor.vue`**:
- Added `resolveLanguage()` helper to map format param to Monaco language ID
- Updated `display()` to accept optional format parameter

**`index.vue`**:
- Parse `format` from queryParams string using `URLSearchParams`
- Thread format through to `showDisplayEditor`

**`src/common/monaco/index.ts`**:
- Import Monaco YAML basic language contribution for tokenizer registration

**Tests**:
- Added 313 spec-compliance tests covering param names, enum values, and boolean completions
- Updated Jest `moduleNameMapper` for monaco-editor subpath imports

Refs #382, #383, #384, #386