### PR TITLE
fix(completion): only suggest field types at value positions inside properties

### DIFF
--- a/src/common/monaco/searchdsl/completionProvider.ts
+++ b/src/common/monaco/searchdsl/completionProvider.ts
@@ -107,9 +107,9 @@ const getCompletionContext = (
     // Check if we're inside a body by looking at the full document
     const fullText = model.getValue();
     const offset = model.getOffsetAt(position);
-    const bodyPath = getBodyPath(fullText, offset);
+    const bodyInfo = getBodyPath(fullText, offset);
 
-    if (bodyPath) {
+    if (bodyInfo) {
       // We're inside a body, provide body completions
       const { method, path } = findMethodAndPath(model, position.lineNumber);
       return {
@@ -118,7 +118,8 @@ const getCompletionContext = (
         position: 'body',
         method,
         path,
-        bodyPath,
+        bodyPath: bodyInfo.path,
+        isValuePosition: bodyInfo.isValuePosition,
       };
     }
 
@@ -194,8 +195,8 @@ const getCompletionContext = (
   const fullText = model.getValue();
   const offset = model.getOffsetAt(position);
 
-  const bodyPath = getBodyPath(fullText, offset);
-  if (bodyPath) {
+  const bodyInfo = getBodyPath(fullText, offset);
+  if (bodyInfo) {
     // Find the method and path for this block
     const { method, path } = findMethodAndPath(model, position.lineNumber);
 
@@ -205,7 +206,8 @@ const getCompletionContext = (
       position: 'body',
       method,
       path,
-      bodyPath,
+      bodyPath: bodyInfo.path,
+      isValuePosition: bodyInfo.isValuePosition,
     };
   }
 
@@ -264,11 +266,16 @@ const findMethodAndPath = (
 
 /**
  * Get the JSON path at the current position in the body
+ * Also indicates whether the cursor is at a value position (after a key+colon pair)
+ * vs a key position (after an opening brace or comma).
  */
-const getBodyPath = (text: string, offset: number): string[] | null => {
+const getBodyPath = (
+  text: string,
+  offset: number,
+): { path: string[]; isValuePosition: boolean } | null => {
   const tokens = tokenize(text);
   const pathStack: string[] = [];
-  let bodyDepth = 0; // Track actual brace depth independently
+  let bodyDepth = 0;
   let lastKey: string | null = null;
 
   for (const token of tokens) {
@@ -297,8 +304,6 @@ const getBodyPath = (text: string, offset: number): string[] | null => {
         break;
       case TokenType.KEY:
       case TokenType.STRING: {
-        // Check if this is a key (followed by colon)
-        // Use >= to include tokens that start right at the end of the current token
         const nextToken = tokens.find(
           t =>
             t.start >= token.end && t.type !== TokenType.WHITESPACE && t.type !== TokenType.NEWLINE,
@@ -309,7 +314,6 @@ const getBodyPath = (text: string, offset: number): string[] | null => {
         break;
       }
       case TokenType.COLON:
-        // After a colon, we're expecting a value
         break;
       case TokenType.COMMA:
         lastKey = null;
@@ -318,7 +322,11 @@ const getBodyPath = (text: string, offset: number): string[] | null => {
   }
 
   // We're in a body if we have unclosed braces
-  return bodyDepth > 0 ? pathStack : null;
+  // isValuePosition: cursor is at a value slot (after key+colon) when lastKey is set
+  if (bodyDepth > 0) {
+    return { path: pathStack, isValuePosition: lastKey !== null };
+  }
+  return null;
 };
 
 /**
@@ -744,7 +752,7 @@ const provideBodyCompletions = (
     }
   } else if (bodyPath[0] === 'mappings' || bodyPath[0] === 'properties') {
     const lastSegment = bodyPath[bodyPath.length - 1];
-    if (lastSegment === 'properties' || lastSegment === 'fields') {
+    if ((lastSegment === 'properties' || lastSegment === 'fields') && context.isValuePosition) {
       const fieldTypes = getFieldTypeOptions();
       for (const fieldType of fieldTypes) {
         completions.push({

--- a/src/common/monaco/searchdsl/types.ts
+++ b/src/common/monaco/searchdsl/types.ts
@@ -95,6 +95,8 @@ export type CompletionContext = {
   method?: HttpMethod;
   path?: string;
   bodyPath?: string[];
+  /** Whether the cursor is at a JSON value position (after a key:colon pair) */
+  isValuePosition?: boolean;
   currentParam?: string;
   typedParams?: string[];
 };

--- a/tests/common/monaco/searchdsl/completionProvider.test.ts
+++ b/tests/common/monaco/searchdsl/completionProvider.test.ts
@@ -36,6 +36,7 @@ jest.mock('monaco-editor', () => ({
       Property: 9,
       Class: 5,
       Value: 12,
+      TypeParameter: 25,
     },
     CompletionItemInsertTextRule: {
       None: 0,
@@ -712,7 +713,7 @@ describe('grammarCompletionProvider', () => {
   });
 
   describe('nested properties in mappings', () => {
-    it('should provide field types directly inside properties block', () => {
+    it('should NOT provide field types at KEY position inside properties block', () => {
       const text = `PUT test_index/_mapping
 {
   properties: {
@@ -721,6 +722,23 @@ describe('grammarCompletionProvider', () => {
 }`;
       const model = createMockModel(text);
       const position = { lineNumber: 4, column: 5 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('text');
+      expect(labels).not.toContain('keyword');
+    });
+
+    it('should provide field types at VALUE position inside properties block', () => {
+      const text = `PUT test_index/_mapping
+{
+  properties: {
+    "f1": 
+  }
+}`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 4, column: 10 };
 
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
@@ -774,7 +792,7 @@ describe('grammarCompletionProvider', () => {
       expect(labels).not.toContain('keyword');
     });
 
-    it('should provide field types directly inside nested object properties', () => {
+    it('should NOT provide field types at KEY position inside nested object properties', () => {
       const text = `PUT test_index/_mapping
 {
   properties: {
@@ -792,11 +810,33 @@ describe('grammarCompletionProvider', () => {
       const result = grammarCompletionProvider(model, position as monaco.Position);
 
       const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('text');
+      expect(labels).not.toContain('keyword');
+    });
+
+    it('should provide field types at VALUE position inside nested object properties', () => {
+      const text = `PUT test_index/_mapping
+{
+  properties: {
+    author: {
+      type: "object",
+      properties: {
+        "name": 
+      }
+    }
+  }
+}`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 7, column: 16 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
       expect(labels).toContain('text');
       expect(labels).toContain('keyword');
     });
 
-    it('should provide field types directly inside fields subfield properties', () => {
+    it('should NOT provide field types at KEY position inside fields subfield', () => {
       const text = `PUT test_index/_mapping
 {
   properties: {
@@ -813,6 +853,28 @@ describe('grammarCompletionProvider', () => {
 }`;
       const model = createMockModel(text);
       const position = { lineNumber: 10, column: 7 };
+
+      const result = grammarCompletionProvider(model, position as monaco.Position);
+
+      const labels = result.suggestions.map(s => s.label);
+      expect(labels).not.toContain('text');
+      expect(labels).not.toContain('keyword');
+    });
+
+    it('should provide field types at VALUE position inside fields subfield', () => {
+      const text = `PUT test_index/_mapping
+{
+  properties: {
+    title: {
+      type: "text",
+      fields: {
+        "raw": 
+      }
+    }
+  }
+}`;
+      const model = createMockModel(text);
+      const position = { lineNumber: 7, column: 15 };
 
       const result = grammarCompletionProvider(model, position as monaco.Position);
 


### PR DESCRIPTION
## Summary

Fixes the remaining issue from #386 where field type snippets (text, keyword, etc.) were incorrectly shown at KEY positions inside properties/fields blocks.

### Before

```
PUT my-index/_mapping
{
  "properties": {
    <- field types (text, keyword...) incorrectly shown here
  }
}
```

### After

```
PUT my-index/_mapping
{
  "properties": {
    <- no field types - user types field name then colon
  }
}
```

```
PUT my-index/_mapping
{
  "properties": {
    "title": <- field types correctly shown here (value position)
  }
}
```

## Root Cause

getBodyPath() only tracked the structural JSON path but discarded token-level context. Both `properties: { | }` and `properties: { "f1": | }` produced the same bodyPath=["properties"], making them indistinguishable.

## Fix

- getBodyPath() now returns `{ path: string[]; isValuePosition: boolean }` instead of `string[] | null`
- provideBodyCompletions() gates field type suggestions on `(lastSegment === 'properties' || lastSegment === 'fields') && context.isValuePosition`
- No changes to query/aggregation/settings completions.

## Test Changes

All 88 tests pass. Added 4 new positive tests for VALUE position, updated 4 existing tests.

## Related

Refs #386