### PR TITLE
fix(dynamodb): partiql validation and import for new tables

### DIFF
--- a/src/common/monaco/partiql/validation.ts
+++ b/src/common/monaco/partiql/validation.ts
@@ -115,9 +115,9 @@ const validatePartiqlStatement = (statement: string, startLine: number): Validat
 
   // UPDATE validation
   if (firstWord === 'UPDATE') {
-    if (!upperStatement.includes('SET')) {
+    if (!upperStatement.includes('SET') && !upperStatement.includes('REMOVE')) {
       errors.push({
-        message: 'UPDATE statement requires SET clause',
+        message: 'UPDATE statement requires SET or REMOVE clause',
         startLineNumber: startLine,
         endLineNumber: startLine + statement.split('\n').length - 1,
         startColumn: 1,

--- a/src/store/importExportStore.ts
+++ b/src/store/importExportStore.ts
@@ -3,7 +3,13 @@ import { ulid } from 'ulidx';
 import { get } from 'lodash';
 import { defineStore } from 'pinia';
 import { CustomError, debug, jsonify, retryWithBackoff, isRetryableError } from '../common';
-import { dynamoApi, esApi, loadHttpClient, sourceFileApi } from '../datasources';
+import {
+  dynamoApi,
+  esApi,
+  loadHttpClient,
+  sourceFileApi,
+  type DynamoDBTableInfo,
+} from '../datasources';
 import { buildEsMappingBody } from '../views/import-export/utils/schemaMapping';
 import {
   Connection,
@@ -612,9 +618,10 @@ export const useImportExportStore = defineStore('importExportStore', {
         };
         this.syncImportProgressToTask();
 
+        let tableInfo: DynamoDBTableInfo | null = null;
         let attributeTypeMap: Map<string, string> | undefined;
         try {
-          const tableInfo = await dynamoApi.describeTable(dynamoConnection, tableName);
+          tableInfo = await dynamoApi.describeTable(dynamoConnection, tableName);
           if (tableInfo?.attributeDefinitions) {
             attributeTypeMap = new Map<string, string>();
             for (const attr of tableInfo.attributeDefinitions) {
@@ -627,8 +634,8 @@ export const useImportExportStore = defineStore('importExportStore', {
 
         const batchSize = 25;
         const fileBatchSize = 1000;
-        const partitionKeyName = tableSummary?.partitionKey?.name;
-        const sortKeyName = tableSummary?.sortKey?.name;
+        const partitionKeyName = tableSummary?.partitionKey?.name ?? tableInfo?.partitionKey?.name;
+        const sortKeyName = tableSummary?.sortKey?.name ?? tableInfo?.sortKey?.name;
 
         if (!partitionKeyName) {
           throw new CustomError(400, `Table ${tableName} has no partition key metadata`);


### PR DESCRIPTION
## Summary
- Fix PartiQL UPDATE statement validation to accept `REMOVE` clause (in addition to `SET`)
- Fix DynamoDB import to newly created tables by using `describeTable` result as fallback for partition key info

## Changes
1. **PartiQL Validation** (`src/common/monaco/partiql/validation.ts`)
   - DynamoDB PartiQL supports `UPDATE ... REMOVE ... WHERE ...` syntax to remove attributes from an item
   - The validation logic was incorrectly requiring `SET` clause for all UPDATE statements
   - Now accepts either `SET` or `REMOVE`

2. **DynamoDB Import** (`src/store/importExportStore.ts`)
   - When importing to a newly created table, `findTable()` returns null because the table isn't in the cached connection store
   - This caused `restoreToDynamoDB()` to fail with "Table has no partition key metadata"
   - Now uses the live `describeTable` API result as fallback when `findTable` returns null

## Testing
- TypeScript check passes (`npx tsc --noEmit`)
- ESLint passes (`npx eslint --fix`)
- PartiQL statements like `UPDATE "table" REMOVE "attr" WHERE ...` no longer show validation errors