### PR TITLE
fix(completion): use InsertAsSnippet for query language commands

### DIFF
--- a/src/common/monaco/searchdsl/completionProvider.ts
+++ b/src/common/monaco/searchdsl/completionProvider.ts
@@ -761,7 +761,7 @@ const provideBodyCompletions = (
         label: cmd.label,
         kind: monaco.languages.CompletionItemKind.Keyword,
         insertText: cmd.insertText,
-        insertTextRules: monaco.languages.CompletionItemInsertTextRule.None,
+        insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
         detail: cmd.description,
         sortText: String(cmd.sortOrder).padStart(3, '0'),
         range,


### PR DESCRIPTION
## Summary

- Fix snippet placeholder (`$0`) leaking into query language command completions
- Change `insertTextRules` from `None` to `InsertAsSnippet` for command keywords

## Problem

When accepting completions for query language commands (ESQL, SQL, EQL, PPL) inside the `query` body field of `_query`, `_sql`, `_eql/search`, and `_plugins/_ppl` endpoints, the literal text `$0` was inserted into the editor.

For example, completing `WHERE` produced `WHERE $0` instead of `WHERE ` with cursor positioned after it.

## Root Cause

The command definitions use Monaco snippet placeholders in their `insertText`:
```typescript
{ label: 'WHERE', insertText: 'WHERE $0', ... }
```

But the completion provider used `InsertTextRule.None`, which inserts text literally without interpreting snippet syntax.

## Fix

Changed `insertTextRules` at `completionProvider.ts:764`:
```diff
- insertTextRules: monaco.languages.CompletionItemInsertTextRule.None,
+ insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
```

This affects all four query languages: ESQL, SQL, EQL, and PPL.

## Verification

- ✅ ESLint clean
- ✅ TypeScript type check clean
- ✅ No other instances of this bug in the codebase (audited all `insertTextRules` usages)

Refers: #412