### PR TITLE
feat(accessibility): comprehensive keyboard navigation support (#396)

### DIFF
--- a/src/components/path-breadcrumb.vue
+++ b/src/components/path-breadcrumb.vue
@@ -3,7 +3,14 @@
     <template v-if="props.clickable && breadCrumbPath">
       <template v-for="(path, index) in breadCrumbPath?.split('/')" :key="index">
         <span v-if="index !== 0" class="breadcrumb-separator">/</span>
-        <span class="breadcrumb-item clickable" @click="handleBreadcrumb(index)">
+        <span
+          class="breadcrumb-item clickable"
+          role="link"
+          tabindex="0"
+          @click="handleBreadcrumb(index)"
+          @keydown.enter="handleBreadcrumb(index)"
+          @keydown.space.prevent="handleBreadcrumb(index)"
+        >
           <span v-if="index !== 0" class="i-carbon-folder breadcrumb-icon" />
           {{ path }}
         </span>

--- a/src/components/tool-bar.vue
+++ b/src/components/tool-bar.vue
@@ -37,11 +37,18 @@
       <template #option="{ option }">
         <span class="flex items-center gap-1 w-full">
           <span
-            class="h-3.5 w-3.5 shrink-0 cursor-pointer"
+            class="h-3.5 w-3.5 shrink-0 cursor-pointer focus:ring-2 focus:ring-primary focus:outline-none"
             :class="
               option.favorite ? 'i-carbon-star-filled text-yellow-400' : 'i-carbon-star opacity-40'
             "
+            role="button"
+            tabindex="0"
+            :aria-label="
+              option.favorite ? $t('toolBar.unfavoriteTable') : $t('toolBar.favoriteTable')
+            "
             @click.stop="toggleFavoriteTable(option.value)"
+            @keydown.enter.stop="toggleFavoriteTable(option.value)"
+            @keydown.space.prevent.stop="toggleFavoriteTable(option.value)"
           />
           {{ option.label }}
         </span>

--- a/src/components/ui/combobox/SearchableSelect.vue
+++ b/src/components/ui/combobox/SearchableSelect.vue
@@ -1,9 +1,19 @@
 <script setup lang="ts">
-import { nextTick } from 'vue';
+import { computed, ref } from 'vue';
+import {
+  ComboboxAnchor,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxItemIndicator,
+  ComboboxPortal,
+  ComboboxRoot,
+  ComboboxTrigger,
+  ComboboxViewport,
+} from 'radix-vue';
 import type { ComboboxOption } from './types';
 import { cn } from '@/lib/utils';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 
 const props = withDefaults(
@@ -40,9 +50,9 @@ const emits = defineEmits<{
   (e: 'open', isOpen: boolean): void;
 }>();
 
+const searchTerm = ref('');
 const open = ref(false);
-const searchQuery = ref('');
-const searchInputRef = ref<HTMLInputElement>();
+const selectedValue = ref(props.modelValue);
 
 const showSearch = computed(
   () => props.options.length > props.searchThreshold || props.allowCreate,
@@ -55,120 +65,160 @@ const selectedLabel = computed(() => {
   return undefined;
 });
 
-const filteredOptions = computed(() => {
-  if (!searchQuery.value.trim()) {
-    return props.options;
-  }
-  const query = searchQuery.value.toLowerCase();
-  return props.options.filter(
-    opt => opt.label.toLowerCase().includes(query) || opt.value.toLowerCase().includes(query),
+const filteredOptions = computed(() => props.options);
+
+const showCreateNew = computed(() => {
+  const trimmed = searchTerm.value.trim().toLowerCase();
+  if (!props.allowCreate || !trimmed) return false;
+  return !props.options.some(
+    opt => opt.value.toLowerCase() === trimmed || opt.label.toLowerCase() === trimmed,
   );
 });
 
-const showCreateNew = computed(() => {
-  const trimmed = searchQuery.value.trim();
-  if (!props.allowCreate || !trimmed) return false;
-  return !props.options.some(opt => opt.value === trimmed || opt.label === trimmed);
-});
+const customFilter = (values: string[], term: string) => {
+  if (!term.trim()) return values;
+  const query = term.toLowerCase();
+  return values.filter(value => {
+    const opt = props.options.find(o => o.value === value);
+    if (!opt) return value === term.trim();
+    return opt.label.toLowerCase().includes(query) || opt.value.toLowerCase().includes(query);
+  });
+};
 
-const selectOption = (value: string) => {
-  emits('update:modelValue', value);
+const handleUpdateModelValue = (value: string | number) => {
+  emits('update:modelValue', String(value));
   open.value = false;
 };
 
-watch(open, async isOpen => {
+watch(
+  () => props.modelValue,
+  newValue => {
+    selectedValue.value = newValue;
+  },
+);
+
+watch(open, isOpen => {
   if (!isOpen) {
-    searchQuery.value = '';
-  } else if (showSearch.value) {
-    await nextTick();
-    searchInputRef.value?.focus();
+    searchTerm.value = '';
   }
   emits('open', isOpen);
 });
 </script>
 
 <template>
-  <Popover v-model:open="open">
-    <PopoverTrigger as-child>
-      <Button
-        :variant="variant"
-        role="combobox"
-        :disabled="disabled"
-        :class="cn('justify-between font-normal', props.class)"
-      >
-        <template v-if="open && showSearch">
-          <input
-            ref="searchInputRef"
-            v-model="searchQuery"
-            :placeholder="searchPlaceholder || placeholder"
-            class="flex-1 border-0 outline-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground"
-            autocomplete="off"
-            autocorrect="off"
-            autocapitalize="off"
-            spellcheck="false"
-            @click.stop
-            @keydown.escape="open = false"
-          />
-          <span class="i-carbon-search h-4 w-4 ml-2 shrink-0 opacity-50" />
-        </template>
-        <template v-else>
+  <ComboboxRoot
+    v-model="selectedValue"
+    v-model:open="open"
+    :disabled="disabled"
+    :filter-function="customFilter"
+    @update:model-value="handleUpdateModelValue"
+  >
+    <ComboboxAnchor :class="cn('w-full', props.class)">
+      <ComboboxTrigger as-child>
+        <button
+          type="button"
+          :class="[
+            'flex w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+            variant === 'ghost' && 'border-transparent hover:bg-accent',
+          ]"
+          :disabled="disabled"
+        >
           <slot name="selected-prepend" />
           <span v-if="selectedLabel" class="truncate">{{ selectedLabel }}</span>
           <span v-else class="text-muted-foreground truncate">{{ placeholder }}</span>
           <span class="i-carbon-chevron-down h-4 w-4 ml-2 shrink-0 opacity-50" />
-        </template>
-      </Button>
-    </PopoverTrigger>
-    <PopoverContent :align="'start'" class="w-[--radix-popover-trigger-width] p-0">
-      <div class="macos-scrollable max-h-[280px] overflow-y-scroll">
-        <div
-          v-for="option in filteredOptions"
-          :key="option.value"
-          :class="[
-            'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
-            option.disabled && 'pointer-events-none opacity-50',
-            option.value === modelValue && 'bg-accent text-accent-foreground',
-          ]"
-          @click="!option.disabled && selectOption(option.value)"
-        >
-          <slot name="option" :option="option">
-            {{ option.label }}
-          </slot>
-        </div>
+        </button>
+      </ComboboxTrigger>
+    </ComboboxAnchor>
 
-        <div
-          v-if="filteredOptions.length === 0 && searchQuery && !showCreateNew && !loading"
-          class="flex flex-col items-center gap-2 px-2 py-8 text-center text-sm text-muted-foreground"
-        >
-          <span class="i-carbon-search h-5 w-5 opacity-40" />
-          <span>No results for "{{ searchQuery }}"</span>
-        </div>
-
-        <div
-          v-if="showCreateNew"
-          class="relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none text-[#18a058] italic hover:bg-accent"
-          @click="selectOption(searchQuery.trim())"
-        >
-          <span class="i-carbon-add h-4 w-4" />
-          {{ createText }}: "{{ searchQuery.trim() }}"
-        </div>
-      </div>
-
-      <div
-        v-if="filteredOptions.length === 0 && !searchQuery && !loading"
-        class="flex flex-col items-center gap-2 px-2 py-8 text-center text-sm text-muted-foreground"
+    <ComboboxPortal>
+      <ComboboxContent
+        :class="
+          cn(
+            'relative z-50 max-h-[280px] w-[--radix-combobox-trigger-width] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            'p-0',
+          )
+        "
+        position="popper"
+        :side-offset="4"
       >
-        <span class="i-carbon-incomplete h-5 w-5 opacity-40" />
-        {{ emptyText }}
-      </div>
+        <div v-if="showSearch" class="flex items-center border-b border-border px-3 py-2">
+          <ComboboxInput
+            v-model="searchTerm"
+            :placeholder="searchPlaceholder || placeholder"
+            class="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+          />
+          <span class="i-carbon-search h-4 w-4 ml-2 shrink-0 opacity-50" />
+        </div>
 
-      <div
-        v-if="loading"
-        class="flex items-center justify-center py-4 gap-2 text-sm text-muted-foreground"
-      >
-        <Spinner class="h-4 w-4" />
-        Loading...
-      </div>
-    </PopoverContent>
-  </Popover>
+        <ComboboxViewport :class="cn('p-1', !showSearch && 'max-h-[280px] overflow-y-auto')">
+          <div
+            v-if="loading"
+            class="flex items-center justify-center py-4 gap-2 text-sm text-muted-foreground"
+          >
+            <Spinner class="h-4 w-4" />
+            Loading...
+          </div>
+
+          <template v-else>
+            <ComboboxItem
+              v-for="option in filteredOptions"
+              :key="option.value"
+              :value="option.value"
+              :disabled="option.disabled"
+              :class="
+                cn(
+                  'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors',
+                  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+                  'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground',
+                  option.value === modelValue && 'bg-accent text-accent-foreground',
+                )
+              "
+            >
+              <ComboboxItemIndicator
+                class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center"
+              >
+                <span class="i-carbon-checkmark h-4 w-4" />
+              </ComboboxItemIndicator>
+              <span class="pl-6">
+                <slot name="option" :option="option">
+                  {{ option.label }}
+                </slot>
+              </span>
+            </ComboboxItem>
+
+            <ComboboxItem
+              v-if="showCreateNew"
+              :value="searchTerm.trim()"
+              class="relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none text-[#18a058] italic data-[highlighted]:bg-accent"
+            >
+              <span class="i-carbon-add h-4 w-4" />
+              {{ createText }}: "{{ searchTerm.trim() }}"
+            </ComboboxItem>
+
+            <ComboboxEmpty v-if="!showCreateNew">
+              <div
+                v-if="searchTerm"
+                class="flex flex-col items-center gap-2 px-2 py-8 text-center text-sm text-muted-foreground"
+              >
+                <span class="i-carbon-search h-5 w-5 opacity-40" />
+                <span>No results for "{{ searchTerm }}"</span>
+              </div>
+              <div
+                v-else
+                class="flex flex-col items-center gap-2 px-2 py-8 text-center text-sm text-muted-foreground"
+              >
+                <span class="i-carbon-incomplete h-5 w-5 opacity-40" />
+                {{ emptyText }}
+              </div>
+            </ComboboxEmpty>
+          </template>
+        </ComboboxViewport>
+      </ComboboxContent>
+    </ComboboxPortal>
+  </ComboboxRoot>
 </template>

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -463,6 +463,8 @@ export const enUS = {
   toolBar: {
     includeSystemIndices: 'Include System indices',
     systemIndices: 'System indices',
+    favoriteTable: 'Favorite Table',
+    unfavoriteTable: 'Unfavorite Table',
   },
   dialogOps: {
     warning: 'Warning',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -457,6 +457,8 @@ export const zhCN = {
   toolBar: {
     includeSystemIndices: '包含系统索引',
     systemIndices: '系统索引',
+    favoriteTable: '收藏数据表',
+    unfavoriteTable: '取消收藏数据表',
   },
   dialogOps: {
     warning: '提示',

--- a/src/layout/components/the-aside.vue
+++ b/src/layout/components/the-aside.vue
@@ -12,7 +12,11 @@
             :class="{
               active: isActive(item),
             }"
+            role="button"
+            tabindex="0"
             @click="navClick(item)"
+            @keydown.enter="navClick(item)"
+            @keydown.space.prevent="navClick(item)"
           >
             <span :class="[item.iconClass, 'h-6 w-6']" />
           </div>
@@ -29,7 +33,11 @@
             :class="{
               active: isActive(item),
             }"
+            role="button"
+            tabindex="0"
             @click="navClick(item)"
+            @keydown.enter="navClick(item)"
+            @keydown.space.prevent="navClick(item)"
           >
             <span :class="[item.iconClass, 'h-6 w-6']" />
           </div>

--- a/src/layout/components/tool-bar-right.vue
+++ b/src/layout/components/tool-bar-right.vue
@@ -11,7 +11,11 @@
         <div
           class="icon-item"
           :class="{ active: item.id === selectedItemId }"
+          role="button"
+          tabindex="0"
           @click="navClick(item)"
+          @keydown.enter="navClick(item)"
+          @keydown.space.prevent="navClick(item)"
         >
           <span :class="[item.iconClass, 'h-6 w-6']" />
           <span v-if="item.id === 'task-manager' && runningTaskCount > 0" class="task-badge">

--- a/src/views/connect/components/connect-list.vue
+++ b/src/views/connect/components/connect-list.vue
@@ -55,10 +55,18 @@
     <div class="connection-scroll-container">
       <div v-if="filteredConnections.length > 0" class="connection-list-body">
         <div
-          v-for="connection in filteredConnections"
+          v-for="(connection, index) in filteredConnections"
           :key="connection.id"
-          class="connection-card"
+          class="connection-card focus:ring-2 focus:ring-primary focus:outline-none"
+          role="button"
+          tabindex="0"
           @dblclick="handleSelect('connect', connection)"
+          @keydown.enter="handleSelect('connect', connection)"
+          @keydown.space.prevent="handleSelect('connect', connection)"
+          @keydown.right.prevent="focusConnectionNode(index + 1)"
+          @keydown.left.prevent="focusConnectionNode(index - 1)"
+          @keydown.down.prevent="focusConnectionNode(index + getConnectionGridColumns())"
+          @keydown.up.prevent="focusConnectionNode(index - getConnectionGridColumns())"
         >
           <!-- Top section: icon -->
           <div class="card-top">
@@ -483,6 +491,20 @@ const removeConnect = (connection: Connection) => {
 
 const esConnectDialog = ref();
 const dynamodbConnectDialog = ref();
+
+const getConnectionGridColumns = () => {
+  const container = document.querySelector('.connection-list-body');
+  if (!container) return 1;
+  const gridComputedStyle = window.getComputedStyle(container);
+  return gridComputedStyle.getPropertyValue('grid-template-columns').split(' ').length;
+};
+
+const focusConnectionNode = (index: number) => {
+  const items = document.querySelectorAll('.connection-card');
+  if (index >= 0 && index < items.length) {
+    (items[index] as HTMLElement)?.focus();
+  }
+};
 
 const selectDatabaseType = (type: DatabaseType) => {
   if (type === DatabaseType.ELASTICSEARCH) {

--- a/src/views/connect/components/connect-list.vue
+++ b/src/views/connect/components/connect-list.vue
@@ -60,7 +60,7 @@
           class="connection-card focus:ring-2 focus:ring-primary focus:outline-none"
           role="button"
           tabindex="0"
-          @dblclick="handleSelect('connect', connection)"
+          @click="handleSelect('connect', connection)"
           @keydown.enter="handleSelect('connect', connection)"
           @keydown.space.prevent="handleSelect('connect', connection)"
           @keydown.right.prevent="focusConnectionNode(index + 1)"

--- a/src/views/connect/components/dynamodb-connect-dialog.vue
+++ b/src/views/connect/components/dynamodb-connect-dialog.vue
@@ -8,6 +8,7 @@
         </DialogTitle>
         <button
           class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none"
+          aria-label="Close"
           @click="closeModal"
         >
           <X class="h-4 w-4" />
@@ -18,7 +19,11 @@
         <Alert v-if="successMessage" variant="success" class="mb-4">
           <AlertDescription class="flex items-center justify-between">
             {{ successMessage }}
-            <button class="ml-2 hover:opacity-70 cursor-pointer" @click="successMessage = ''">
+            <button
+              class="ml-2 hover:opacity-70 cursor-pointer"
+              aria-label="Dismiss"
+              @click="successMessage = ''"
+            >
               <X class="w-4 h-4" />
             </button>
           </AlertDescription>
@@ -26,7 +31,11 @@
         <Alert v-if="errorMessage" variant="destructive" class="mb-4">
           <AlertDescription class="flex items-center justify-between">
             {{ errorMessage }}
-            <button class="ml-2 hover:opacity-70 cursor-pointer" @click="errorMessage = ''">
+            <button
+              class="ml-2 hover:opacity-70 cursor-pointer"
+              aria-label="Dismiss"
+              @click="errorMessage = ''"
+            >
               <X class="w-4 h-4" />
             </button>
           </AlertDescription>
@@ -444,7 +453,9 @@
                     autocomplete="off"
                     @focus="showSuggestions = true"
                     @blur="onInputBlur"
-                    @keydown.enter.prevent="addFromInputOrFirst"
+                    @keydown.up.prevent="handleSuggestionKeyDown"
+                    @keydown.down.prevent="handleSuggestionKeyDown"
+                    @keydown.enter.prevent="handleSuggestionKeyDown"
                     @keydown.escape="showSuggestions = false"
                   />
                   <div
@@ -452,10 +463,13 @@
                     class="absolute z-50 w-full mt-1 bg-popover border border-border rounded-md shadow-md max-h-48 overflow-y-scroll suggestion-list macos-scrollable"
                   >
                     <button
-                      v-for="name in filteredSuggestions"
+                      v-for="(name, index) in filteredSuggestions"
                       :key="name"
                       type="button"
-                      class="w-full text-left px-3 py-1.5 text-sm hover:bg-accent cursor-pointer"
+                      :class="[
+                        'w-full text-left px-3 py-1.5 text-sm hover:bg-accent cursor-pointer',
+                        index === highlightedSuggestionIndex && 'bg-accent',
+                      ]"
                       @mousedown.prevent="addFilterTableName(name)"
                     >
                       {{ name }}
@@ -1321,12 +1335,45 @@ const onInputBlur = () => {
   }, 150);
 };
 
-const addFromInputOrFirst = () => {
-  const name = filterTableNameInput.value.trim();
-  if (name) {
-    addFilterTableName(name);
-  } else if (filteredSuggestions.value.length) {
-    addFilterTableName(filteredSuggestions.value[0]);
+const highlightedSuggestionIndex = ref(-1);
+
+watch(filterTableNameInput, () => {
+  highlightedSuggestionIndex.value = -1;
+});
+
+const handleSuggestionKeyDown = (e: KeyboardEvent) => {
+  const suggestions = filteredSuggestions.value;
+
+  switch (e.key) {
+    case 'ArrowDown':
+      if (!suggestions.length) return;
+      e.preventDefault();
+      highlightedSuggestionIndex.value =
+        highlightedSuggestionIndex.value < suggestions.length - 1
+          ? highlightedSuggestionIndex.value + 1
+          : 0;
+      break;
+    case 'ArrowUp':
+      if (!suggestions.length) return;
+      e.preventDefault();
+      highlightedSuggestionIndex.value =
+        highlightedSuggestionIndex.value > 0
+          ? highlightedSuggestionIndex.value - 1
+          : suggestions.length - 1;
+      break;
+    case 'Enter':
+      e.preventDefault();
+      if (highlightedSuggestionIndex.value >= 0 && suggestions[highlightedSuggestionIndex.value]) {
+        addFilterTableName(suggestions[highlightedSuggestionIndex.value]);
+      } else {
+        const name = filterTableNameInput.value.trim();
+        if (name) {
+          addFilterTableName(name);
+        } else if (suggestions.length) {
+          addFilterTableName(suggestions[0]);
+        }
+      }
+      break;
   }
 };
 

--- a/src/views/connect/components/es-connect-dialog.vue
+++ b/src/views/connect/components/es-connect-dialog.vue
@@ -8,6 +8,7 @@
         </DialogTitle>
         <button
           class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none"
+          aria-label="Close"
           @click="closeModal"
         >
           <X class="h-4 w-4" />
@@ -18,7 +19,11 @@
         <Alert v-if="successMessage" variant="success" class="mb-4">
           <AlertDescription class="flex items-center justify-between">
             {{ successMessage }}
-            <button class="ml-2 hover:opacity-70 cursor-pointer" @click="successMessage = ''">
+            <button
+              class="ml-2 hover:opacity-70 cursor-pointer"
+              aria-label="Dismiss"
+              @click="successMessage = ''"
+            >
               <X class="w-4 h-4" />
             </button>
           </AlertDescription>
@@ -26,7 +31,11 @@
         <Alert v-if="errorMessage" variant="destructive" class="mb-4">
           <AlertDescription class="flex items-center justify-between">
             {{ errorMessage }}
-            <button class="ml-2 hover:opacity-70 cursor-pointer" @click="errorMessage = ''">
+            <button
+              class="ml-2 hover:opacity-70 cursor-pointer"
+              aria-label="Dismiss"
+              @click="errorMessage = ''"
+            >
               <X class="w-4 h-4" />
             </button>
           </AlertDescription>

--- a/src/views/editor/dynamo-editor/components/delete-confirm-modal.vue
+++ b/src/views/editor/dynamo-editor/components/delete-confirm-modal.vue
@@ -5,6 +5,7 @@
         <DialogTitle>{{ lang.t('dialogOps.warning') }}</DialogTitle>
         <button
           class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none"
+          aria-label="Close"
           @click="handleCancel"
         >
           <Icon :size="20" :component="X" />
@@ -20,7 +21,11 @@
         <Alert v-else-if="resultMessage" variant="destructive" class="mb-4">
           <AlertDescription class="flex items-center justify-between">
             {{ resultMessage }}
-            <button class="ml-2 hover:opacity-70 cursor-pointer" @click="resultMessage = ''">
+            <button
+              class="ml-2 hover:opacity-70 cursor-pointer"
+              aria-label="Dismiss"
+              @click="resultMessage = ''"
+            >
               <X class="w-4 h-4" />
             </button>
           </AlertDescription>
@@ -37,6 +42,7 @@
           variant="destructive"
           :disabled="loading"
           @click="handleRetry"
+          @keydown.enter.prevent="handleRetry"
         >
           <Loader2 v-if="loading" class="mr-2 h-4 w-4 animate-spin" />
           {{ lang.t('dialogOps.retry') }}
@@ -46,6 +52,7 @@
           variant="destructive"
           :disabled="loading"
           @click="handleConfirm"
+          @keydown.enter.prevent="handleConfirm"
         >
           <Loader2 v-if="loading" class="mr-2 h-4 w-4 animate-spin" />
           {{ lang.t('dialogOps.delete') }}

--- a/src/views/editor/dynamo-editor/components/sql-editor.vue
+++ b/src/views/editor/dynamo-editor/components/sql-editor.vue
@@ -10,17 +10,19 @@
           :style="{ top: `${contextMenuPosition.y}px`, left: `${contextMenuPosition.x}px` }"
           @click.stop
         >
-          <ul>
-            <li @click="handleContextMenuAction('execute')">
-              <span>{{ lang.t('editor.dynamo.partiql.contextMenu.execute') }}</span>
-              <span class="shortcut">{{ cmdKey }}↵</span>
-            </li>
-            <li @click="handleContextMenuAction('format')">
-              <span>{{ lang.t('editor.dynamo.partiql.contextMenu.format') }}</span>
-              <span class="shortcut">{{ cmdKey }}I</span>
-            </li>
-            <li @click="handleContextMenuAction('copy')">
-              <span>{{ lang.t('editor.dynamo.partiql.contextMenu.copy') }}</span>
+          <ul ref="contextMenuRef" role="menu" @keydown="handleMenuKeydown">
+            <li
+              v-for="(item, index) in menuItems"
+              :key="item.action"
+              role="menuitem"
+              tabindex="-1"
+              :class="['menu-item', index === highlightedIndex && 'bg-accent']"
+              @click="handleContextMenuAction(item.action as any)"
+              @keydown.enter.prevent="handleContextMenuAction(item.action as any)"
+              @keydown.space.prevent="handleContextMenuAction(item.action as any)"
+            >
+              <span>{{ item.label }}</span>
+              <span v-if="item.shortcut" class="shortcut">{{ item.shortcut }}</span>
             </li>
           </ul>
         </div>
@@ -135,6 +137,59 @@ const debouncedValidate = createDebouncedValidator((model: monaco.editor.ITextMo
 const contextMenuVisible = ref(false);
 const contextMenuPosition = ref({ x: 0, y: 0 });
 const contextMenuStatementLine = ref<number | null>(null);
+
+const cmdKey = computed(() => (platform() === 'macos' ? '⌘' : 'Ctrl+'));
+
+const contextMenuRef = ref<HTMLElement | null>(null);
+const highlightedIndex = ref(0);
+
+const menuItems = computed(() => [
+  {
+    action: 'execute',
+    label: lang.t('editor.dynamo.partiql.contextMenu.execute'),
+    shortcut: `${cmdKey.value}↵`,
+  },
+  {
+    action: 'format',
+    label: lang.t('editor.dynamo.partiql.contextMenu.format'),
+    shortcut: `${cmdKey.value}I`,
+  },
+  { action: 'copy', label: lang.t('editor.dynamo.partiql.contextMenu.copy') },
+]);
+
+const handleMenuKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    highlightedIndex.value = (highlightedIndex.value + 1) % menuItems.value.length;
+    focusMenuItem(highlightedIndex.value);
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    highlightedIndex.value =
+      (highlightedIndex.value - 1 + menuItems.value.length) % menuItems.value.length;
+    focusMenuItem(highlightedIndex.value);
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    hideContextMenu();
+  }
+};
+
+const focusMenuItem = (index: number) => {
+  nextTick(() => {
+    if (contextMenuRef.value) {
+      const items = contextMenuRef.value.querySelectorAll('li');
+      if (items[index]) {
+        (items[index] as HTMLElement).focus();
+      }
+    }
+  });
+};
+
+watch(contextMenuVisible, visible => {
+  if (visible) {
+    highlightedIndex.value = 0;
+    focusMenuItem(0);
+  }
+});
 
 const insertSampleQuery = (key: string) => {
   if (!editor) return;
@@ -325,8 +380,6 @@ const hideContextMenu = () => {
   contextMenuVisible.value = false;
   contextMenuStatementLine.value = null;
 };
-
-const cmdKey = computed(() => (platform() === 'macos' ? '⌘' : 'Ctrl+'));
 
 /**
  * Handle context menu action
@@ -658,6 +711,29 @@ const setupEditor = () => {
       saveModelContent(true, true, true);
     });
   }
+
+  // Keyboard shortcut for context menu (Shift+F10 or ContextMenu key)
+  editor.addAction({
+    id: 'show-context-menu',
+    label: 'Show Context Menu',
+    keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.F10],
+    run: ed => {
+      const position = ed.getPosition();
+      if (!position) return;
+
+      const coords = ed.getScrolledVisiblePosition(position);
+      const domNode = ed.getDomNode();
+      if (coords && domNode) {
+        const rect = domNode.getBoundingClientRect();
+        contextMenuPosition.value = {
+          x: rect.left + coords.left,
+          y: rect.top + coords.top + 20, // offset slightly below cursor
+        };
+        contextMenuStatementLine.value = position.lineNumber;
+        contextMenuVisible.value = true;
+      }
+    },
+  });
 
   // Layout-dependent shortcuts (/) are handled via DOM keydown events
   // instead of Monaco's addCommand, which assumes US keyboard layout.

--- a/src/views/editor/dynamo-editor/components/ui-editor.vue
+++ b/src/views/editor/dynamo-editor/components/ui-editor.vue
@@ -75,7 +75,14 @@
             <Card class="additional-filter-container mt-4">
               <CardHeader class="p-3 flex flex-row items-center justify-between">
                 <CardTitle class="text-base">{{ $t('editor.dynamo.filterTitle') }}</CardTitle>
-                <span class="i-carbon-add h-6 w-6 cursor-pointer" @click="addFilterItem" />
+                <span
+                  class="i-carbon-add h-6 w-6 cursor-pointer"
+                  role="button"
+                  tabindex="0"
+                  @click="addFilterItem"
+                  @keydown.enter="addFilterItem"
+                  @keydown.space.prevent="addFilterItem"
+                />
               </CardHeader>
               <CardContent class="filter-card-content p-3">
                 <ScrollArea class="filter-scroll-area">

--- a/src/views/editor/es-editor/index.vue
+++ b/src/views/editor/es-editor/index.vue
@@ -10,17 +10,19 @@
           :style="{ top: `${contextMenuPosition.y}px`, left: `${contextMenuPosition.x}px` }"
           @click.stop
         >
-          <ul>
-            <li @click="handleContextMenuAction('execute')">
-              <span>{{ lang.t('editor.es.contextMenu.execute') }}</span>
-              <span class="shortcut">{{ cmdKey }}↵</span>
-            </li>
-            <li @click="handleContextMenuAction('autoIndent')">
-              <span>{{ lang.t('editor.es.contextMenu.autoIndent') }}</span>
-              <span class="shortcut">{{ cmdKey }}I</span>
-            </li>
-            <li @click="handleContextMenuAction('copyAsCurl')">
-              <span>{{ lang.t('editor.es.contextMenu.copyAsCurl') }}</span>
+          <ul ref="contextMenuRef" role="menu" @keydown="handleMenuKeydown">
+            <li
+              v-for="(item, index) in menuItems"
+              :key="item.action"
+              role="menuitem"
+              tabindex="-1"
+              :class="['menu-item', index === highlightedIndex && 'bg-accent']"
+              @click="handleContextMenuAction(item.action as any)"
+              @keydown.enter.prevent="handleContextMenuAction(item.action as any)"
+              @keydown.space.prevent="handleContextMenuAction(item.action as any)"
+            >
+              <span>{{ item.label }}</span>
+              <span v-if="item.shortcut" class="shortcut">{{ item.shortcut }}</span>
             </li>
           </ul>
         </div>
@@ -36,7 +38,7 @@ import { open } from '@tauri-apps/plugin-shell';
 import { listen } from '@tauri-apps/api/event';
 import { platform } from '@tauri-apps/plugin-os';
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch, nextTick } from 'vue';
 import { SplitPane } from '@/components/ui/split-pane';
 import { useMessageService, useLoadingBarService } from '@/composables';
 import { CustomError, jsonify } from '../../../common';
@@ -108,6 +110,57 @@ const contextMenuVisible = ref(false);
 const contextMenuPosition = ref({ x: 0, y: 0 });
 const contextMenuActionLine = ref<number | null>(null);
 const cmdKey = computed(() => (platform() === 'macos' ? '⌘' : 'Ctrl+'));
+
+const contextMenuRef = ref<HTMLElement | null>(null);
+const highlightedIndex = ref(0);
+
+const menuItems = computed(() => [
+  {
+    action: 'execute',
+    label: lang.t('editor.es.contextMenu.execute'),
+    shortcut: `${cmdKey.value}↵`,
+  },
+  {
+    action: 'autoIndent',
+    label: lang.t('editor.es.contextMenu.autoIndent'),
+    shortcut: `${cmdKey.value}I`,
+  },
+  { action: 'copyAsCurl', label: lang.t('editor.es.contextMenu.copyAsCurl') },
+]);
+
+const handleMenuKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    highlightedIndex.value = (highlightedIndex.value + 1) % menuItems.value.length;
+    focusMenuItem(highlightedIndex.value);
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    highlightedIndex.value =
+      (highlightedIndex.value - 1 + menuItems.value.length) % menuItems.value.length;
+    focusMenuItem(highlightedIndex.value);
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    hideContextMenu();
+  }
+};
+
+const focusMenuItem = (index: number) => {
+  nextTick(() => {
+    if (contextMenuRef.value) {
+      const items = contextMenuRef.value.querySelectorAll('li');
+      if (items[index]) {
+        (items[index] as HTMLElement).focus();
+      }
+    }
+  });
+};
+
+watch(contextMenuVisible, visible => {
+  if (visible) {
+    highlightedIndex.value = 0;
+    focusMenuItem(0);
+  }
+});
 
 // Debounced syntax validation (300ms delay for performance)
 const debouncedValidate = createDebouncedValidator((model: monaco.editor.ITextModel) => {
@@ -525,6 +578,29 @@ const setupQueryEditor = () => {
       saveModelContent(true, true, true);
     });
   }
+
+  // Keyboard shortcut for context menu (Shift+F10 or ContextMenu key)
+  queryEditor.addAction({
+    id: 'show-context-menu',
+    label: 'Show Context Menu',
+    keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.F10],
+    run: ed => {
+      const position = ed.getPosition();
+      if (!position) return;
+
+      const coords = ed.getScrolledVisiblePosition(position);
+      const domNode = ed.getDomNode();
+      if (coords && domNode) {
+        const rect = domNode.getBoundingClientRect();
+        contextMenuPosition.value = {
+          x: rect.left + coords.left,
+          y: rect.top + coords.top + 20, // offset slightly below cursor
+        };
+        contextMenuActionLine.value = position.lineNumber;
+        contextMenuVisible.value = true;
+      }
+    },
+  });
 
   // Layout-dependent shortcuts (/) are handled via DOM keydown events
   // instead of Monaco's addCommand, which assumes US keyboard layout.

--- a/src/views/file/components/context-menu.vue
+++ b/src/views/file/components/context-menu.vue
@@ -1,7 +1,25 @@
 <template>
-  <div class="context-menu" :style="{ top: `${position?.y}px`, left: `${position?.x}px` }">
+  <div
+    ref="menuRef"
+    class="context-menu focus:outline-none"
+    role="menu"
+    tabindex="-1"
+    :style="{ top: `${position?.y}px`, left: `${position?.x}px` }"
+    @keydown.down.prevent="handleMenuKeyDown"
+    @keydown.up.prevent="handleMenuKeyDown"
+    @keydown.enter.prevent="handleMenuKeyDown"
+    @keydown.space.prevent="handleMenuKeyDown"
+    @keydown.escape.prevent="handleMenuKeyDown"
+  >
     <ul>
-      <li v-for="action in actions" :key="action.action" @click="handleAction(action.action)">
+      <li
+        v-for="(action, index) in actions"
+        :key="action.action"
+        role="menuitem"
+        tabindex="-1"
+        :class="['menu-item', index === highlightedMenuIndex && 'bg-accent']"
+        @click="handleAction(action.action)"
+      >
         {{ action.label }}
       </li>
     </ul>
@@ -11,6 +29,7 @@
 <script setup lang="ts">
 import { ContextMenuAction } from '../../../store';
 import { useLang } from '../../../lang';
+import { ref, watchEffect, nextTick } from 'vue';
 
 const props = defineProps({
   position: { type: Object, default: undefined },
@@ -20,6 +39,25 @@ const props = defineProps({
 const lang = useLang();
 
 const actions = ref<Array<{ label: string; action: ContextMenuAction }>>([]);
+const highlightedMenuIndex = ref(-1);
+const menuRef = ref<HTMLElement | null>(null);
+
+const emits = defineEmits(['context-menu-action-emit', 'close']);
+
+const closeMenu = () => {
+  highlightedMenuIndex.value = -1;
+  emits('close');
+};
+
+watchEffect(() => {
+  if (props.position && actions.value.length > 0) {
+    highlightedMenuIndex.value = 0;
+    nextTick(() => {
+      const firstItem = menuRef.value?.querySelector('[role="menuitem"]');
+      (firstItem as HTMLElement)?.focus();
+    });
+  }
+});
 
 watchEffect(() => {
   if (props.file) {
@@ -45,10 +83,50 @@ watchEffect(() => {
   }
 });
 
-const emits = defineEmits(['context-menu-action-emit']);
-
 const handleAction = async (action: ContextMenuAction) => {
   emits('context-menu-action-emit', action);
+  closeMenu();
+};
+
+const handleMenuKeyDown = (e: KeyboardEvent) => {
+  const items = actions.value;
+  if (!items.length) return;
+
+  switch (e.key) {
+    case 'ArrowDown':
+      e.preventDefault();
+      highlightedMenuIndex.value =
+        highlightedMenuIndex.value < items.length - 1 ? highlightedMenuIndex.value + 1 : 0;
+      nextTick(() => {
+        const menuItems = menuRef.value?.querySelectorAll('[role="menuitem"]');
+        if (menuItems && menuItems[highlightedMenuIndex.value]) {
+          (menuItems[highlightedMenuIndex.value] as HTMLElement).focus();
+        }
+      });
+      break;
+    case 'ArrowUp':
+      e.preventDefault();
+      highlightedMenuIndex.value =
+        highlightedMenuIndex.value > 0 ? highlightedMenuIndex.value - 1 : items.length - 1;
+      nextTick(() => {
+        const menuItems = menuRef.value?.querySelectorAll('[role="menuitem"]');
+        if (menuItems && menuItems[highlightedMenuIndex.value]) {
+          (menuItems[highlightedMenuIndex.value] as HTMLElement).focus();
+        }
+      });
+      break;
+    case 'Enter':
+    case ' ':
+      e.preventDefault();
+      if (highlightedMenuIndex.value >= 0) {
+        handleAction(items[highlightedMenuIndex.value].action);
+      }
+      break;
+    case 'Escape':
+      e.preventDefault();
+      closeMenu();
+      break;
+  }
 };
 </script>
 

--- a/src/views/file/components/file-list.vue
+++ b/src/views/file/components/file-list.vue
@@ -17,6 +17,7 @@
           @keydown.left.prevent="focusFileNode(index - 1)"
           @keydown.down.prevent="focusFileNode(index + getGridColumns())"
           @keydown.up.prevent="focusFileNode(index - getGridColumns())"
+          @keydown.shift.f10.prevent="openContextMenuForKeyboard($event, file)"
           @contextmenu.prevent="showContextMenu($event, file)"
         >
           <div class="file-icon">
@@ -118,17 +119,28 @@ const previousFocus = ref<HTMLElement | null>(null);
 const showContextMenu = (event: MouseEvent, file?: PathInfo) => {
   // Prevent the event from propagating further
   event.stopPropagation();
-  previousFocus.value = document.activeElement as HTMLElement;
+  previousFocus.value = event.currentTarget as HTMLElement;
   activeRef.value = file;
   selectedFile.value = file;
   contextMenuPosition.value = { x: event.layerX, y: event.layerY };
   contextMenuVisible.value = true;
 };
 
+const openContextMenuForKeyboard = (event: KeyboardEvent, file: PathInfo) => {
+  previousFocus.value = event.currentTarget as HTMLElement;
+  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+  contextMenuPosition.value = { x: rect.left, y: rect.bottom };
+  selectedFile.value = file;
+  contextMenuVisible.value = true;
+};
+
 const closeContextMenu = () => {
   contextMenuVisible.value = false;
   if (previousFocus.value) {
-    previousFocus.value.focus();
+    const el = previousFocus.value;
+    nextTick(() => {
+      el.focus();
+    });
     previousFocus.value = null;
   }
 };

--- a/src/views/file/components/file-list.vue
+++ b/src/views/file/components/file-list.vue
@@ -6,8 +6,17 @@
           v-for="(file, index) in sortedFileList"
           :key="file.path"
           :class="getClass(file, index)"
+          class="focus:ring-2 focus:ring-primary focus:outline-none"
+          role="button"
+          tabindex="0"
           @click="handleClick(ClickType.SINGLE, file)"
           @dblclick="handleClick(ClickType.DOUBLE, file)"
+          @keydown.enter="handleClick(ClickType.DOUBLE, file)"
+          @keydown.space.prevent="handleClick(ClickType.SINGLE, file)"
+          @keydown.right.prevent="focusFileNode(index + 1)"
+          @keydown.left.prevent="focusFileNode(index - 1)"
+          @keydown.down.prevent="focusFileNode(index + getGridColumns())"
+          @keydown.up.prevent="focusFileNode(index - getGridColumns())"
           @contextmenu.prevent="showContextMenu($event, file)"
         >
           <div class="file-icon">
@@ -29,13 +38,14 @@
               {{ formatSize(file.size) }}
             </span>
           </div>
-          <context-menu
-            v-if="contextMenuVisible"
-            :position="contextMenuPosition"
-            :file="selectedFile"
-            @context-menu-action-emit="handleContextMenu"
-          />
         </div>
+        <context-menu
+          v-if="contextMenuVisible"
+          :position="contextMenuPosition"
+          :file="selectedFile"
+          @context-menu-action-emit="handleContextMenu"
+          @close="closeContextMenu"
+        />
         <new-file-dialog ref="newFileDialogRef" />
       </div>
     </ScrollArea>
@@ -103,24 +113,34 @@ const selectedFile = ref<PathInfo>();
 const newFileDialogRef = ref();
 const contextMenuVisible = ref(false);
 const contextMenuPosition = ref({ x: 0, y: 0 });
+const previousFocus = ref<HTMLElement | null>(null);
 
 const showContextMenu = (event: MouseEvent, file?: PathInfo) => {
   // Prevent the event from propagating further
   event.stopPropagation();
+  previousFocus.value = document.activeElement as HTMLElement;
   activeRef.value = file;
   selectedFile.value = file;
   contextMenuPosition.value = { x: event.layerX, y: event.layerY };
   contextMenuVisible.value = true;
 };
 
+const closeContextMenu = () => {
+  contextMenuVisible.value = false;
+  if (previousFocus.value) {
+    previousFocus.value.focus();
+    previousFocus.value = null;
+  }
+};
+
 const handleClickOutside = (event: MouseEvent) => {
   if (!(event.target as HTMLElement).closest('.context-menu')) {
-    contextMenuVisible.value = false;
+    closeContextMenu();
   }
 };
 
 const handleContextMenu = async (action: ContextMenuAction) => {
-  contextMenuVisible.value = false;
+  closeContextMenu();
   if (action === ContextMenuAction.CONTEXT_MENU_ACTION_OPEN) {
     if (selectedFile.value?.type === PathTypeEnum.FOLDER) {
       await changeDirectory(selectedFile.value?.path);
@@ -139,6 +159,20 @@ const handleContextMenu = async (action: ContextMenuAction) => {
     deleteFileOrFolder(selectedFile.value?.path ?? '');
   } else {
     newFileDialogRef.value.showModal(action, selectedFile.value);
+  }
+};
+
+const getGridColumns = () => {
+  const container = document.querySelector('.grid-container');
+  if (!container) return 1;
+  const gridComputedStyle = window.getComputedStyle(container);
+  return gridComputedStyle.getPropertyValue('grid-template-columns').split(' ').length;
+};
+
+const focusFileNode = (index: number) => {
+  const items = document.querySelectorAll('.file-item');
+  if (index >= 0 && index < items.length) {
+    (items[index] as HTMLElement)?.focus();
   }
 };
 

--- a/src/views/file/components/new-file-dialog.vue
+++ b/src/views/file/components/new-file-dialog.vue
@@ -5,7 +5,7 @@
         <DialogTitle>{{ modalTitle }}</DialogTitle>
       </DialogHeader>
       <div class="modal-content">
-        <Form>
+        <Form @submit.prevent="submitNewFile">
           <FormItem :label="$t('file.name')" required>
             <Input
               v-model="formData.path"
@@ -20,7 +20,7 @@
       </div>
       <DialogFooter>
         <Button variant="outline" @click="closeModal">{{ $t('dialogOps.cancel') }}</Button>
-        <Button :disabled="!validationPassed || saveLoading" @click="submitNewFile">
+        <Button type="submit" :disabled="!validationPassed || saveLoading">
           <Loader2 v-if="saveLoading" class="mr-2 h-4 w-4 animate-spin" />
           {{ $t('dialogOps.confirm') }}
         </Button>

--- a/src/views/import-export/components/export-target-output.vue
+++ b/src/views/import-export/components/export-target-output.vue
@@ -28,20 +28,20 @@
         <GridItem>
           <div class="field-label">{{ $t('export.destinationPath') }}</div>
           <div class="destination-path-row">
-            <div class="folder-selector" @click="handleSelectFolder">
-              <Button variant="outline" size="icon">
+            <button
+              class="folder-selector-btn"
+              type="button"
+              @click="handleSelectFolder"
+              @keydown.enter="handleSelectFolder"
+              @keydown.space.prevent="handleSelectFolder"
+            >
+              <div class="folder-icon-wrapper">
                 <span class="i-carbon-folder-open h-4 w-4" />
-              </Button>
-              <Input
-                :model-value="folderPath || $t('export.selectFolderPlaceholder')"
-                readonly
-                class="folder-path-input cursor-pointer"
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-              />
-            </div>
+              </div>
+              <div class="folder-path-content">
+                {{ folderPath || $t('export.selectFolderPlaceholder') }}
+              </div>
+            </button>
             <span class="path-separator">/</span>
             <Input
               v-model="extraPath"
@@ -220,23 +220,52 @@ watch(fileType, newType => {
   gap: 8px;
 }
 
-.step-card .destination-path-row .folder-selector {
+.step-card .destination-path-row .folder-selector-btn {
   flex: 1;
   display: flex;
+  align-items: center;
+  padding: 0;
+  border: 1px solid hsl(var(--input));
+  border-radius: calc(var(--radius) - 2px);
+  background-color: transparent;
   cursor: pointer;
-  gap: 0;
+  overflow: hidden;
+  transition: colors 0.2s;
+  height: 40px;
 }
 
-.step-card .destination-path-row .folder-selector .folder-path-input {
-  flex: 1;
-  cursor: pointer;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
+.step-card .destination-path-row .folder-selector-btn:hover {
+  background-color: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
 }
 
-.step-card .destination-path-row .folder-selector button {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
+.step-card .destination-path-row .folder-selector-btn:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+}
+
+.step-card .destination-path-row .folder-selector-btn .folder-icon-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 100%;
+  border-right: 1px solid hsl(var(--input));
+  flex-shrink: 0;
+}
+
+.step-card .destination-path-row .folder-selector-btn .folder-path-content {
+  padding: 0 12px;
+  font-size: 14px;
+  color: hsl(var(--foreground));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+}
+
+.step-card .destination-path-row .folder-selector-btn:hover .folder-icon-wrapper {
+  border-right-color: hsl(var(--input));
 }
 
 .step-card .destination-path-row .path-separator {

--- a/src/views/manage/components/alias-dialog.vue
+++ b/src/views/manage/components/alias-dialog.vue
@@ -5,7 +5,7 @@
         <DialogTitle>{{ $t('manage.index.newAliasForm.title') }}</DialogTitle>
       </DialogHeader>
       <div class="modal-content">
-        <Form>
+        <Form @submit.prevent="submitCreate">
           <Grid :cols="8" :x-gap="10" :y-gap="10">
             <GridItem :span="8">
               <FormItem
@@ -117,7 +117,7 @@
       </div>
       <DialogFooter>
         <Button variant="outline" @click="closeModal">{{ $t('dialogOps.cancel') }}</Button>
-        <Button :disabled="!validationPassed || createLoading" @click="submitCreate">
+        <Button type="submit" :disabled="!validationPassed || createLoading">
           <Loader2 v-if="createLoading" class="mr-2 h-4 w-4 animate-spin" />
           {{ $t('dialogOps.create') }}
         </Button>

--- a/src/views/manage/components/cluster-state.vue
+++ b/src/views/manage/components/cluster-state.vue
@@ -286,7 +286,14 @@
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead class="sortable-header" @click="handleIndexSort('index')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleIndexSort('index')"
+                      @keydown.enter="handleIndexSort('index')"
+                      @keydown.space.prevent="handleIndexSort('index')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.index') }}
                         <span
@@ -297,7 +304,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleIndexSort('health')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleIndexSort('health')"
+                      @keydown.enter="handleIndexSort('health')"
+                      @keydown.space.prevent="handleIndexSort('health')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.health') }}
                         <span
@@ -308,7 +322,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleIndexSort('status')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleIndexSort('status')"
+                      @keydown.enter="handleIndexSort('status')"
+                      @keydown.space.prevent="handleIndexSort('status')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.status') }}
                         <span
@@ -319,7 +340,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleIndexSort('docs')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleIndexSort('docs')"
+                      @keydown.enter="handleIndexSort('docs')"
+                      @keydown.space.prevent="handleIndexSort('docs')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.docs') }}
                         <span
@@ -330,7 +358,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleIndexSort('storage')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleIndexSort('storage')"
+                      @keydown.enter="handleIndexSort('storage')"
+                      @keydown.space.prevent="handleIndexSort('storage')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.storage') }}
                         <span
@@ -432,6 +467,7 @@
                                 ]"
                                 :title="`${shard.prirep === 'p' ? 'Primary' : 'Replica'} shard ${shard.shard} — ${shard.state}${!shard.node ? ' (unassigned)' : ''}`"
                                 @click="openShardDetail(row.index, shard)"
+                                @keydown.enter="openShardDetail(row.index, shard)"
                               >
                                 {{ shard.prirep }}{{ shard.shard }}
                               </Button>
@@ -536,7 +572,14 @@
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead class="sortable-header" @click="handleTemplateSort('name')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleTemplateSort('name')"
+                      @keydown.enter="handleTemplateSort('name')"
+                      @keydown.space.prevent="handleTemplateSort('name')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.name') }}
                         <span
@@ -547,7 +590,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleTemplateSort('type')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleTemplateSort('type')"
+                      @keydown.enter="handleTemplateSort('type')"
+                      @keydown.space.prevent="handleTemplateSort('type')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.type') }}
                         <span
@@ -558,7 +608,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleTemplateSort('precedence')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleTemplateSort('precedence')"
+                      @keydown.enter="handleTemplateSort('precedence')"
+                      @keydown.space.prevent="handleTemplateSort('precedence')"
+                    >
                       <span class="sortable-header-content">
                         {{ templatePrecedenceLabel }}
                         <span
@@ -573,7 +630,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleTemplateSort('version')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleTemplateSort('version')"
+                      @keydown.enter="handleTemplateSort('version')"
+                      @keydown.space.prevent="handleTemplateSort('version')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.version') }}
                         <span
@@ -586,7 +650,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleTemplateSort('mappings')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleTemplateSort('mappings')"
+                      @keydown.enter="handleTemplateSort('mappings')"
+                      @keydown.space.prevent="handleTemplateSort('mappings')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.mappings') }}
                         <span
@@ -599,7 +670,14 @@
                         />
                       </span>
                     </TableHead>
-                    <TableHead class="sortable-header" @click="handleTemplateSort('settings')">
+                    <TableHead
+                      class="sortable-header"
+                      role="columnheader"
+                      tabindex="0"
+                      @click="handleTemplateSort('settings')"
+                      @keydown.enter="handleTemplateSort('settings')"
+                      @keydown.space.prevent="handleTemplateSort('settings')"
+                    >
                       <span class="sortable-header-content">
                         {{ lang.t('manage.columns.settings') }}
                         <span

--- a/src/views/manage/components/create-index-modal.vue
+++ b/src/views/manage/components/create-index-modal.vue
@@ -5,7 +5,7 @@
         <DialogTitle>{{ lang.t('manage.dynamo.createGsiTitle') }}</DialogTitle>
       </DialogHeader>
       <ScrollArea class="max-h-[65vh] pr-4">
-        <Form>
+        <Form @submit.prevent="handleSubmit">
           <!-- Index Details Section -->
           <div class="section-divider">
             <Separator />
@@ -292,7 +292,7 @@
         <Button variant="outline" :disabled="loading" @click="handleCancel">
           {{ lang.t('dialogOps.cancel') }}
         </Button>
-        <Button :disabled="loading" @click="handleSubmit">
+        <Button type="submit" :disabled="loading">
           <Loader2 v-if="loading" class="mr-2 h-4 w-4 animate-spin" />
           {{ lang.t('dialogOps.create') }}
         </Button>

--- a/src/views/manage/components/delete-index-modal.vue
+++ b/src/views/manage/components/delete-index-modal.vue
@@ -13,7 +13,11 @@
       <Alert v-else-if="resultMessage" variant="destructive" class="mb-3">
         <AlertDescription class="flex items-center justify-between">
           <span>{{ resultMessage }}</span>
-          <button class="ml-2 text-sm hover:opacity-70 cursor-pointer" @click="resultMessage = ''">
+          <button
+            class="ml-2 text-sm hover:opacity-70 cursor-pointer"
+            aria-label="Dismiss"
+            @click="resultMessage = ''"
+          >
             <X class="w-4 h-4" />
           </button>
         </AlertDescription>
@@ -33,6 +37,7 @@
           variant="destructive"
           :disabled="loading"
           @click="handleRetry"
+          @keydown.enter.prevent="handleRetry"
         >
           <Spinner v-if="loading" class="mr-2 h-4 w-4" />
           {{ lang.t('dialogOps.retry') }}
@@ -42,6 +47,7 @@
           variant="destructive"
           :disabled="loading"
           @click="handleConfirm"
+          @keydown.enter.prevent="handleConfirm"
         >
           <Spinner v-if="loading" class="mr-2 h-4 w-4" />
           {{ lang.t('dialogOps.delete') }}

--- a/src/views/manage/components/dynamo-table-manage.vue
+++ b/src/views/manage/components/dynamo-table-manage.vue
@@ -292,7 +292,11 @@
               <!-- Streams Setting -->
               <div
                 class="setting-item clickable"
+                role="button"
+                tabindex="0"
                 @click="message.info($t('manage.dynamo.comingSoon'))"
+                @keydown.enter="message.info($t('manage.dynamo.comingSoon'))"
+                @keydown.space.prevent="message.info($t('manage.dynamo.comingSoon'))"
               >
                 <div class="setting-header">
                   <span class="setting-label">{{ $t('manage.dynamo.streams') }}</span>
@@ -311,7 +315,11 @@
               <!-- Table Class Setting -->
               <div
                 class="setting-item clickable"
+                role="button"
+                tabindex="0"
                 @click="message.info($t('manage.dynamo.comingSoon'))"
+                @keydown.enter="message.info($t('manage.dynamo.comingSoon'))"
+                @keydown.space.prevent="message.info($t('manage.dynamo.comingSoon'))"
               >
                 <div class="setting-header">
                   <span class="setting-label">{{ $t('manage.dynamo.tableClass') }}</span>

--- a/src/views/manage/components/index-dialog.vue
+++ b/src/views/manage/components/index-dialog.vue
@@ -5,7 +5,7 @@
         <DialogTitle>{{ $t('manage.index.newIndexForm.title') }}</DialogTitle>
       </DialogHeader>
       <div class="modal-content">
-        <Form>
+        <Form @submit.prevent="submitCreate">
           <Grid :cols="8" :x-gap="10" :y-gap="10">
             <GridItem :span="8">
               <FormItem
@@ -100,7 +100,7 @@
       </div>
       <DialogFooter>
         <Button variant="outline" @click="closeModal">{{ $t('dialogOps.cancel') }}</Button>
-        <Button :disabled="!validationPassed || createLoading" @click="submitCreate">
+        <Button type="submit" :disabled="!validationPassed || createLoading">
           <Loader2 v-if="createLoading" class="mr-2 h-4 w-4 animate-spin" />
           {{ $t('dialogOps.create') }}
         </Button>

--- a/src/views/manage/components/modify-index-modal.vue
+++ b/src/views/manage/components/modify-index-modal.vue
@@ -5,7 +5,7 @@
         <DialogTitle>{{ lang.t('manage.dynamo.modifyGsiTitle') }}</DialogTitle>
       </DialogHeader>
 
-      <Form>
+      <Form @submit.prevent="handleSubmit">
         <FormItem :label="lang.t('manage.dynamo.indexName')">
           <span class="text-sm">{{ props.indexName }}</span>
         </FormItem>
@@ -42,7 +42,11 @@
       <Alert v-if="errorMessage" variant="destructive" class="mt-3">
         <AlertDescription class="flex items-center justify-between">
           <span>{{ errorMessage }}</span>
-          <button class="ml-2 text-sm hover:opacity-70 cursor-pointer" @click="errorMessage = ''">
+          <button
+            class="ml-2 text-sm hover:opacity-70 cursor-pointer"
+            aria-label="Dismiss"
+            @click="errorMessage = ''"
+          >
             <X class="w-4 h-4" />
           </button>
         </AlertDescription>
@@ -52,7 +56,7 @@
         <Button variant="outline" :disabled="loading" @click="handleCancel">
           {{ lang.t('dialogOps.cancel') }}
         </Button>
-        <Button :disabled="loading" @click="handleSubmit">
+        <Button type="submit" :disabled="loading">
           <Spinner v-if="loading" class="mr-2 h-4 w-4" />
           {{ lang.t('dialogOps.confirm') }}
         </Button>

--- a/src/views/manage/components/node-state.vue
+++ b/src/views/manage/components/node-state.vue
@@ -3,10 +3,16 @@
     <ScrollArea class="node-scroll-area">
       <div class="node-list-container">
         <Card
-          v-for="node in nodes"
+          v-for="(node, index) in nodes"
           :key="node.name"
-          class="node-item hover:bg-accent cursor-pointer"
+          class="node-item hover:bg-accent cursor-pointer focus:ring-2 focus:ring-primary focus:outline-none"
+          role="button"
+          tabindex="0"
           @click="handleNodeClick(node.name)"
+          @keydown.enter="handleNodeClick(node.name)"
+          @keydown.space.prevent="handleNodeClick(node.name)"
+          @keydown.up.prevent="focusPrevNode(index)"
+          @keydown.down.prevent="focusNextNode(index, nodes.length)"
         >
           <CardHeader class="pb-2">
             <CardTitle class="text-base">{{ node.name }}</CardTitle>
@@ -151,6 +157,20 @@ const nodeStats = ref<Array<NodeStats>>([
 ]);
 
 const nodeStatistics = ref<Array<NodeStatistics>>([]);
+
+const focusPrevNode = (currentIndex: number) => {
+  if (currentIndex > 0) {
+    const prevItem = document.querySelectorAll('.node-item')[currentIndex - 1];
+    (prevItem as HTMLElement)?.focus();
+  }
+};
+
+const focusNextNode = (currentIndex: number, totalItems: number) => {
+  if (currentIndex < totalItems - 1) {
+    const nextItem = document.querySelectorAll('.node-item')[currentIndex + 1];
+    (nextItem as HTMLElement)?.focus();
+  }
+};
 
 const handleNodeClick = async (nodeName: string) => {
   const selectedNode = nodes.value.find(node => node.name === nodeName);

--- a/src/views/manage/components/shard-manage.vue
+++ b/src/views/manage/components/shard-manage.vue
@@ -45,6 +45,7 @@
                     size="xs"
                     class="shard-box m-1"
                     @click="handleShardClick(shard)"
+                    @keydown.enter="handleShardClick(shard)"
                   >
                     {{ shard.prirep }}{{ shard.shard }}
                   </Button>
@@ -66,7 +67,14 @@
               }}, unassigned: {{ indexShards.shards.filter(shard => !shard.node).length }}
             </span>
           </h3>
-          <span class="i-carbon-close h-6 w-6 close-index-shard-icon" @click="closeindexShards" />
+          <span
+            class="i-carbon-close h-6 w-6 close-index-shard-icon"
+            role="button"
+            tabindex="0"
+            @click="closeindexShards"
+            @keydown.enter="closeindexShards"
+            @keydown.space.prevent="closeindexShards"
+          />
         </div>
 
         <div class="shard-list-scrollbar-box">

--- a/src/views/manage/components/switch-alias-dialog.vue
+++ b/src/views/manage/components/switch-alias-dialog.vue
@@ -5,7 +5,7 @@
         <DialogTitle>{{ $t('manage.index.switchAliasForm.title') }}</DialogTitle>
       </DialogHeader>
       <div class="modal-content">
-        <Form>
+        <Form @submit.prevent="submitCreate">
           <Grid :cols="8" :x-gap="10" :y-gap="10">
             <GridItem :span="8">
               <FormItem :label="$t('manage.index.switchAliasForm.aliasName')">
@@ -48,7 +48,7 @@
       </div>
       <DialogFooter>
         <Button variant="outline" @click="closeModal">{{ $t('dialogOps.cancel') }}</Button>
-        <Button :disabled="!validationPassed || createLoading" @click="submitCreate">
+        <Button type="submit" :disabled="!validationPassed || createLoading">
           <Loader2 v-if="createLoading" class="mr-2 h-4 w-4 animate-spin" />
           {{ $t('dialogOps.confirm') }}
         </Button>

--- a/src/views/manage/components/table-settings-modal.vue
+++ b/src/views/manage/components/table-settings-modal.vue
@@ -15,7 +15,7 @@
 
         <!-- Streams Tab -->
         <TabsContent value="streams">
-          <Form class="space-y-4 pt-4">
+          <Form class="space-y-4 pt-4" @submit.prevent="handleSubmit">
             <FormItem :label="lang.t('manage.dynamo.enableStreams')">
               <Switch
                 :checked="formValue.streamsEnabled"
@@ -46,7 +46,7 @@
 
         <!-- TTL Tab -->
         <TabsContent value="ttl">
-          <Form class="space-y-4 pt-4">
+          <Form class="space-y-4 pt-4" @submit.prevent="handleSubmit">
             <FormItem :label="lang.t('manage.dynamo.enableTtl')">
               <Switch
                 :checked="formValue.ttlEnabled"
@@ -64,7 +64,7 @@
 
         <!-- PITR Tab -->
         <TabsContent value="pitr">
-          <Form class="space-y-4 pt-4">
+          <Form class="space-y-4 pt-4" @submit.prevent="handleSubmit">
             <FormItem :label="lang.t('manage.dynamo.enablePitr')">
               <Switch
                 :checked="formValue.pitrEnabled"
@@ -79,7 +79,7 @@
 
         <!-- Table Class Tab -->
         <TabsContent value="tableClass">
-          <Form class="space-y-4 pt-4">
+          <Form class="space-y-4 pt-4" @submit.prevent="handleSubmit">
             <FormItem :label="lang.t('manage.dynamo.tableClass')">
               <Select v-model="formValue.tableClass">
                 <SelectTrigger class="w-full">
@@ -106,7 +106,11 @@
       <Alert v-if="errorMessage" variant="destructive" class="mt-3">
         <AlertDescription class="flex items-center justify-between">
           <span>{{ errorMessage }}</span>
-          <button class="ml-2 text-sm hover:opacity-70 cursor-pointer" @click="errorMessage = ''">
+          <button
+            class="ml-2 text-sm hover:opacity-70 cursor-pointer"
+            aria-label="Dismiss"
+            @click="errorMessage = ''"
+          >
             <X class="w-4 h-4" />
           </button>
         </AlertDescription>
@@ -116,7 +120,7 @@
         <Button variant="outline" :disabled="loading" @click="handleCancel">
           {{ lang.t('dialogOps.cancel') }}
         </Button>
-        <Button :disabled="loading" @click="handleSubmit">
+        <Button type="submit" :disabled="loading">
           <Spinner v-if="loading" class="mr-2 h-4 w-4" />
           {{ lang.t('dialogOps.save') }}
         </Button>

--- a/src/views/manage/components/template-dialog.vue
+++ b/src/views/manage/components/template-dialog.vue
@@ -5,7 +5,7 @@
         <DialogTitle>{{ $t('manage.index.newTemplateForm.title') }}</DialogTitle>
       </DialogHeader>
 
-      <Form class="mt-4">
+      <Form class="mt-4" @submit.prevent="submitCreate">
         <div class="form-grid">
           <!-- Row 1: Template Name -->
           <div class="form-row-full">
@@ -89,7 +89,7 @@
 
       <DialogFooter>
         <Button variant="outline" @click="closeModal">{{ $t('dialogOps.cancel') }}</Button>
-        <Button :disabled="createLoading" @click="submitCreate">
+        <Button type="submit" :disabled="createLoading">
           <Loader2 v-if="createLoading" class="mr-2 h-4 w-4 animate-spin" />
           {{ $t('dialogOps.create') }}
         </Button>


### PR DESCRIPTION
## Summary

Implements comprehensive keyboard accessibility improvements across the entire application, resolving #396.

### Key Changes

**SearchableSelect Component** - Migrated to Radix Vue Combobox for built-in keyboard support (ArrowUp/Down/Enter/Escape)

**Interactive Elements** - Added `tabindex`, `role="button"`, `@keydown.enter`, `@keydown.space` to connection cards, file items, navigation icons, toolbar favorites, breadcrumb items, node cards, and table headers

**Form Submission** - Added `@submit.prevent` to 8 modal dialog forms for proper Enter key submission

**Confirmation Dialogs** - Scoped Enter key to confirm buttons only, preventing accidental destructive actions

**Context Menus** - Full keyboard support with ARIA roles, focus management, and Shift+F10 opener for editor context menus

**Aria Labels** - Added to icon-only buttons in 6 dialog files

## Test Plan

- [x] Tab/Shift+Tab navigation through all interactive elements
- [x] Enter/Space activation on buttons, cards, and menu items
- [x] Arrow key navigation in dropdowns, lists, and grids
- [x] Escape to close popovers, dialogs, and context menus
- [x] Shift+F10 to open editor context menus
- [ ] Form submission via Enter key in modal dialogs
- [x] SearchableSelect keyboard navigation (search, select, create new)

## Related Issues

Refer #396

## Screenshots

N/A - Accessibility improvements are non-visual