### PR TITLE
feat(agent): add MongoDB native support in Data Studio agent

### DIFF
--- a/src-tauri/src/agent/executor.rs
+++ b/src-tauri/src/agent/executor.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
 use base64::Engine;
+use futures::TryStreamExt;
+use mongodb::bson::{doc, Bson, Document};
+use mongodb::{options::ClientOptions, Client as MongoClient};
 use serde_json::{json, Value};
 
 use crate::common::http_client::create_http_client;
@@ -459,6 +462,291 @@ async fn execute_dynamo_tool(
     }
 }
 
+fn build_mongo_uri(config: &Value) -> Result<String, String> {
+    let auth_kind = config
+        .get("authKind")
+        .and_then(|v| v.as_str())
+        .unwrap_or("none");
+
+    if auth_kind == "uri" {
+        return config
+            .get("uri")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| "Missing uri in connection config".to_string());
+    }
+
+    let host = config
+        .get("host")
+        .and_then(|v| v.as_str())
+        .unwrap_or("localhost");
+    let port = config
+        .get("port")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(27017);
+    let tls = config
+        .get("tls")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let database = config
+        .get("database")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let db_path = if database.is_empty() {
+        String::new()
+    } else {
+        format!("/{}", database)
+    };
+
+    let mut params: Vec<String> = Vec::new();
+    if tls {
+        params.push("tls=true".to_string());
+    }
+
+    if auth_kind == "scram" {
+        let username = config
+            .get("username")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let password = config
+            .get("password")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let auth_source = config
+            .get("authSource")
+            .and_then(|v| v.as_str())
+            .unwrap_or("admin");
+        params.push(format!("authSource={}", auth_source));
+        if let Some(mechanism) = config.get("authMechanism").and_then(|v| v.as_str()) {
+            if !mechanism.is_empty() {
+                params.push(format!("authMechanism={}", mechanism));
+            }
+        }
+        let query = if params.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", params.join("&"))
+        };
+        Ok(format!(
+            "mongodb://{}:{}@{}:{}{}{}",
+            username, password, host, port, db_path, query
+        ))
+    } else {
+        let query = if params.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", params.join("&"))
+        };
+        Ok(format!("mongodb://{}:{}{}{}", host, port, db_path, query))
+    }
+}
+
+pub(crate) async fn create_mongo_client_from_config(
+    config: &Value,
+) -> Result<(MongoClient, String), String> {
+    let uri = build_mongo_uri(config)?;
+    let database = config
+        .get("database")
+        .and_then(|v| v.as_str())
+        .unwrap_or("test")
+        .to_string();
+    let client_options = ClientOptions::parse(&uri)
+        .await
+        .map_err(|e| format!("Failed to parse MongoDB connection options: {}", e))?;
+    let client = MongoClient::with_options(client_options)
+        .map_err(|e| format!("Failed to create MongoDB client: {}", e))?;
+    Ok((client, database))
+}
+
+fn bson_to_value(bson: &Bson) -> Value {
+    match bson {
+        Bson::Double(v) => json!(*v),
+        Bson::String(v) => json!(v),
+        Bson::Array(arr) => Value::Array(arr.iter().map(bson_to_value).collect()),
+        Bson::Document(d) => {
+            let map: serde_json::Map<String, Value> =
+                d.iter().map(|(k, v)| (k.clone(), bson_to_value(v))).collect();
+            Value::Object(map)
+        }
+        Bson::Boolean(v) => json!(*v),
+        Bson::Null => Value::Null,
+        Bson::Int32(v) => json!(*v),
+        Bson::Int64(v) => json!(*v),
+        Bson::ObjectId(oid) => json!(oid.to_string()),
+        Bson::DateTime(dt) => json!(dt.timestamp_millis()),
+        other => json!(other.to_string()),
+    }
+}
+
+fn json_to_bson_doc_agent(val: &Value) -> Result<Document, String> {
+    mongodb::bson::to_document(val)
+        .map_err(|e| format!("Failed to convert to BSON document: {}", e))
+}
+
+async fn execute_mongo_tool(
+    tool_name: &str,
+    args: &Value,
+    config: &Value,
+) -> Result<String, String> {
+    let (client, db_name) = create_mongo_client_from_config(config).await?;
+
+    match tool_name {
+        "mongo__list_collections" => {
+            let db = client.database(&db_name);
+            let names = db
+                .list_collection_names()
+                .await
+                .map_err(|e| format!("Failed to list collections: {}", e))?;
+            let result = json!({ "collections": names });
+            Ok(truncate_tool_output(result.to_string()))
+        }
+        "mongo__find" => {
+            let collection_name = args
+                .get("collection")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing collection")?;
+            let filter_val = args.get("filter").cloned().unwrap_or(json!({}));
+            let filter = json_to_bson_doc_agent(&filter_val)?;
+            let limit = args
+                .get("limit")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(20)
+                .max(1)
+                .min(100) as i64;
+
+            let db = client.database(&db_name);
+            let coll = db.collection::<Document>(collection_name);
+
+            let mut find_options = mongodb::options::FindOptions::default();
+            find_options.limit = Some(limit);
+            if let Some(sort_val) = args.get("sort") {
+                find_options.sort = Some(json_to_bson_doc_agent(sort_val)?);
+            }
+            if let Some(proj_val) = args.get("projection") {
+                find_options.projection = Some(json_to_bson_doc_agent(proj_val)?);
+            }
+
+            let mut cursor = coll
+                .find(filter)
+                .with_options(find_options)
+                .await
+                .map_err(|e| format!("find failed: {}", e))?;
+            let mut docs: Vec<Value> = Vec::new();
+            while let Some(doc) = cursor
+                .try_next()
+                .await
+                .map_err(|e| format!("cursor error: {}", e))?
+            {
+                docs.push(bson_to_value(&Bson::Document(doc)));
+            }
+            let result = json!({ "count": docs.len(), "documents": docs });
+            Ok(truncate_tool_output(result.to_string()))
+        }
+        "mongo__aggregate" => {
+            let collection_name = args
+                .get("collection")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing collection")?;
+            let pipeline_val = args
+                .get("pipeline")
+                .and_then(|v| v.as_array())
+                .ok_or("Missing or invalid pipeline")?;
+            let pipeline: Vec<Document> = pipeline_val
+                .iter()
+                .map(json_to_bson_doc_agent)
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let db = client.database(&db_name);
+            let coll = db.collection::<Document>(collection_name);
+            let mut cursor = coll
+                .aggregate(pipeline)
+                .await
+                .map_err(|e| format!("aggregate failed: {}", e))?;
+            let mut docs: Vec<Value> = Vec::new();
+            while let Some(doc) = cursor
+                .try_next()
+                .await
+                .map_err(|e| format!("cursor error: {}", e))?
+            {
+                docs.push(bson_to_value(&Bson::Document(doc)));
+                if docs.len() >= 100 {
+                    break;
+                }
+            }
+            let result = json!({ "count": docs.len(), "documents": docs });
+            Ok(truncate_tool_output(result.to_string()))
+        }
+        "mongo__insert_one" => {
+            let collection_name = args
+                .get("collection")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing collection")?;
+            let document_val = args.get("document").ok_or("Missing document")?;
+            let document = json_to_bson_doc_agent(document_val)?;
+
+            let db = client.database(&db_name);
+            let coll = db.collection::<Document>(collection_name);
+            let insert_result = coll
+                .insert_one(document)
+                .await
+                .map_err(|e| format!("insert_one failed: {}", e))?;
+            let inserted_id = bson_to_value(&insert_result.inserted_id);
+            let result = json!({ "inserted_id": inserted_id });
+            Ok(truncate_tool_output(result.to_string()))
+        }
+        "mongo__update_many" => {
+            let collection_name = args
+                .get("collection")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing collection")?;
+            let filter_val = args.get("filter").ok_or("Missing filter")?;
+            let update_val = args.get("update").ok_or("Missing update")?;
+            let filter = json_to_bson_doc_agent(filter_val)?;
+            let update = json_to_bson_doc_agent(update_val)?;
+            let upsert = args
+                .get("upsert")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let db = client.database(&db_name);
+            let coll = db.collection::<Document>(collection_name);
+            let update_options = mongodb::options::UpdateOptions::builder()
+                .upsert(upsert)
+                .build();
+            let update_result = coll
+                .update_many(filter, update)
+                .with_options(update_options)
+                .await
+                .map_err(|e| format!("update_many failed: {}", e))?;
+            let result = json!({
+                "matched_count": update_result.matched_count,
+                "modified_count": update_result.modified_count,
+                "upserted_id": update_result.upserted_id.map(|id| bson_to_value(&id))
+            });
+            Ok(truncate_tool_output(result.to_string()))
+        }
+        "mongo__delete_many" => {
+            let collection_name = args
+                .get("collection")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing collection")?;
+            let filter_val = args.get("filter").ok_or("Missing filter")?;
+            let filter = json_to_bson_doc_agent(filter_val)?;
+
+            let db = client.database(&db_name);
+            let coll = db.collection::<Document>(collection_name);
+            let delete_result = coll
+                .delete_many(filter)
+                .await
+                .map_err(|e| format!("delete_many failed: {}", e))?;
+            let result = json!({ "deleted_count": delete_result.deleted_count });
+            Ok(truncate_tool_output(result.to_string()))
+        }
+        _ => Err(format!("Unknown MongoDB tool: {}", tool_name)),
+    }
+}
+
 #[tauri::command]
 #[allow(dead_code)]
 pub async fn execute_tool(
@@ -477,6 +765,8 @@ pub async fn execute_tool(
         execute_es_tool(&tool_name, &args, &connection_config).await
     } else if tool_name.starts_with("dynamo__") {
         execute_dynamo_tool(&tool_name, &args, &connection_config).await
+    } else if tool_name.starts_with("mongo__") {
+        execute_mongo_tool(&tool_name, &args, &connection_config).await
     } else {
         Err(format!("Unknown tool: {}", tool_name))
     }
@@ -523,6 +813,8 @@ impl crate::agent::tool_executor::ToolExecutor for DocKitToolExecutor {
             execute_es_tool(tool_name, arguments, connection_config).await?
         } else if tool_name.starts_with("dynamo__") {
             execute_dynamo_tool(tool_name, arguments, connection_config).await?
+        } else if tool_name.starts_with("mongo__") {
+            execute_mongo_tool(tool_name, arguments, connection_config).await?
         } else {
             return Err(format!("Unknown tool: {}", tool_name));
         };

--- a/src-tauri/src/agent/schema.rs
+++ b/src-tauri/src/agent/schema.rs
@@ -1,8 +1,10 @@
 use serde_json::{json, Value};
 
-use super::executor::{build_es_base_url, build_es_headers, create_dynamo_client, get_es_ssl_flag};
+use super::executor::{build_es_base_url, build_es_headers, create_dynamo_client, create_mongo_client_from_config, get_es_ssl_flag};
 use crate::common::http_client::create_http_client;
 use crate::dynamo::describe_table::describe_table;
+use futures::TryStreamExt;
+use mongodb::bson::Document;
 
 async fn introspect_es(config: &Value) -> Result<String, String> {
     let base_url = build_es_base_url(config)?;
@@ -86,6 +88,47 @@ async fn introspect_dynamo(config: &Value) -> Result<String, String> {
     serde_json::to_string(&response).map_err(|e| e.to_string())
 }
 
+async fn introspect_mongo(config: &Value) -> Result<String, String> {
+    let (client, db_name) = create_mongo_client_from_config(config).await?;
+    let db = client.database(&db_name);
+
+    let collection_names = db
+        .list_collection_names()
+        .await
+        .map_err(|e| format!("Failed to list collections: {}", e))?;
+
+    let mut collections_schema = serde_json::Map::new();
+    for name in collection_names.iter().take(20) {
+        let coll = db.collection::<Document>(name);
+        let mut cursor = coll
+            .find(mongodb::bson::doc! {})
+            .limit(5)
+            .await
+            .map_err(|e| format!("Failed to sample {}: {}", name, e))?;
+        let mut fields: std::collections::HashSet<String> = std::collections::HashSet::new();
+        while let Some(doc) = cursor
+            .try_next()
+            .await
+            .map_err(|e| format!("cursor error: {}", e))?
+        {
+            for key in doc.keys() {
+                fields.insert(key.clone());
+            }
+        }
+        let mut field_list: Vec<String> = fields.into_iter().collect();
+        field_list.sort();
+        collections_schema.insert(name.clone(), json!(field_list));
+    }
+
+    let schema = json!({
+        "database": db_name,
+        "collections": collection_names,
+        "sample_fields": collections_schema
+    });
+
+    Ok(schema.to_string())
+}
+
 #[tauri::command]
 pub async fn introspect_schema(
     connection_config: serde_json::Value,
@@ -94,6 +137,7 @@ pub async fn introspect_schema(
     match database_type.as_str() {
         "ELASTICSEARCH" | "OPENSEARCH" | "EASYSEARCH" => introspect_es(&connection_config).await,
         "DYNAMODB" => introspect_dynamo(&connection_config).await,
+        "MONGODB" => introspect_mongo(&connection_config).await,
         _ => Err(format!("Unknown database type: {}", database_type)),
     }
 }

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -181,6 +181,99 @@ pub fn all_tools() -> Vec<ToolDefinition> {
             required_permission: "delete",
         },
         ToolDefinition {
+            name: "mongo__find",
+            description: "Query documents from a MongoDB collection using a filter. Returns matching documents. Use for reading and searching data.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "connection_id": { "type": "string", "description": "ID of the target connection from the session" },
+                    "collection": { "type": "string", "description": "Collection name to query" },
+                    "filter": { "type": "object", "description": "MongoDB query filter, e.g. {\"status\": \"active\"}. Use {} for all documents." },
+                    "projection": { "type": "object", "description": "Optional fields to include/exclude, e.g. {\"name\": 1, \"_id\": 0}" },
+                    "limit": { "type": "integer", "description": "Maximum number of documents to return (default 20, max 100)" },
+                    "sort": { "type": "object", "description": "Optional sort specification, e.g. {\"createdAt\": -1}" }
+                },
+                "required": ["connection_id", "collection", "filter"]
+            }),
+            risk_level: RiskLevel::Safe,
+            required_permission: "read",
+        },
+        ToolDefinition {
+            name: "mongo__aggregate",
+            description: "Execute a MongoDB aggregation pipeline on a collection. Use for complex queries, grouping, and transformations. Note: $out and $merge stages are allowed but will modify data.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "connection_id": { "type": "string", "description": "ID of the target connection from the session" },
+                    "collection": { "type": "string", "description": "Collection name" },
+                    "pipeline": { "type": "array", "description": "Aggregation pipeline stages, e.g. [{\"$match\": {\"status\": \"active\"}}, {\"$group\": {\"_id\": \"$category\", \"count\": {\"$sum\": 1}}}]" }
+                },
+                "required": ["connection_id", "collection", "pipeline"]
+            }),
+            risk_level: RiskLevel::Elevated,
+            required_permission: "read",
+        },
+        ToolDefinition {
+            name: "mongo__insert_one",
+            description: "Insert a single document into a MongoDB collection.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "connection_id": { "type": "string", "description": "ID of the target connection from the session" },
+                    "collection": { "type": "string", "description": "Collection name" },
+                    "document": { "type": "object", "description": "Document to insert" }
+                },
+                "required": ["connection_id", "collection", "document"]
+            }),
+            risk_level: RiskLevel::Elevated,
+            required_permission: "create",
+        },
+        ToolDefinition {
+            name: "mongo__update_many",
+            description: "Update documents in a MongoDB collection matching a filter. Use $set, $unset, $inc and other update operators.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "connection_id": { "type": "string", "description": "ID of the target connection from the session" },
+                    "collection": { "type": "string", "description": "Collection name" },
+                    "filter": { "type": "object", "description": "Filter to match documents to update" },
+                    "update": { "type": "object", "description": "Update operations, e.g. {\"$set\": {\"status\": \"inactive\"}}" },
+                    "upsert": { "type": "boolean", "description": "If true, insert a document if none matches the filter (default false)" }
+                },
+                "required": ["connection_id", "collection", "filter", "update"]
+            }),
+            risk_level: RiskLevel::Elevated,
+            required_permission: "update",
+        },
+        ToolDefinition {
+            name: "mongo__delete_many",
+            description: "Delete documents from a MongoDB collection matching a filter. DESTRUCTIVE: permanently removes data.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "connection_id": { "type": "string", "description": "ID of the target connection from the session" },
+                    "collection": { "type": "string", "description": "Collection name" },
+                    "filter": { "type": "object", "description": "Filter to match documents to delete. Use {} to delete ALL documents." }
+                },
+                "required": ["connection_id", "collection", "filter"]
+            }),
+            risk_level: RiskLevel::Destructive,
+            required_permission: "delete",
+        },
+        ToolDefinition {
+            name: "mongo__list_collections",
+            description: "List all collection names in the connected MongoDB database.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "connection_id": { "type": "string", "description": "ID of the target connection from the session" }
+                },
+                "required": ["connection_id"]
+            }),
+            risk_level: RiskLevel::Safe,
+            required_permission: "read",
+        },
+        ToolDefinition {
             name: "dynamo__describe_table",
             description: "Describe a DynamoDB table schema: key schema, attribute definitions, indexes, and throughput.",
             parameters: json!({


### PR DESCRIPTION
## Summary

Closes #434

Adds native MongoDB support to the Data Studio agent, making it work exactly like Elasticsearch and DynamoDB as a first-class data source.

## Changes

### `src-tauri/src/agent/tools.rs`
Six new MongoDB tool definitions following the existing `es__`/`dynamo__` naming convention:

| Tool | Risk | Permission |
|------|------|------------|
| `mongo__find` | safe | read |
| `mongo__aggregate` | elevated | read |
| `mongo__insert_one` | elevated | create |
| `mongo__update_many` | elevated | update |
| `mongo__delete_many` | destructive | delete |
| `mongo__list_collections` | safe | read |

`mongo__aggregate` is marked elevated (not safe) because pipelines can include `$out`/`$merge` write stages.

### `src-tauri/src/agent/executor.rs`
- `build_mongo_uri()` — builds a MongoDB URI from the agent connection config (supporting `none`, `scram`, and `uri` auth kinds)
- `create_mongo_client_from_config()` — public helper returning `(Client, db_name)`
- `bson_to_value()` / `json_to_bson_doc_agent()` — BSON ↔ JSON conversion
- `execute_mongo_tool()` — full implementation of all 6 tools with result capping (100 docs max), proper error propagation for sort/projection conversion, and limit clamped to `[1, 100]`
- Routed `mongo__` prefix in both `execute_tool` and `DocKitToolExecutor::execute`

### `src-tauri/src/agent/schema.rs`
- `introspect_mongo()` — lists all collections and samples up to 5 documents per collection to infer field names, providing the agent with schema context
- Routed `"MONGODB"` in `introspect_schema()`

## What was already in place
The frontend was already fully wired: `MONGODB` in `DatabaseType`, `buildConnectionConfig` handling MongoDB connections, and `DatabaseSource` type including `'MONGODB'`. Only the Rust agent layer was missing.

## Verification
- `cargo build` — ✅ clean
- `npx tsc --noEmit` — ✅ no errors