### PR TITLE
feat(agent): move session metadata from localStorage to agent.sqlite

### DIFF
--- a/src-tauri/src/agent/session_store.rs
+++ b/src-tauri/src/agent/session_store.rs
@@ -11,6 +11,32 @@ pub struct AgentSession {
     pub status: String,
     pub created_at: i64,
     pub updated_at: i64,
+    pub sources: String,
+    pub permissions_mode: String,
+    pub model_id: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ConfirmationRuleRow {
+    pub id: String,
+    pub session_id: String,
+    pub tool_name: String,
+    pub action: String,
+    pub created_at: i64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct AttachedSourceRow {
+    pub id: String,
+    pub kind: String,
+    pub alias: Option<String>,
+    pub name: Option<String>,
+    pub database_type: Option<String>,
+    pub file_type: Option<String>,
+    pub file_path: Option<String>,
+    pub connection_id: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -46,7 +72,7 @@ pub async fn load_agent_sessions(db: State<'_, AgentDb>) -> Result<Vec<AgentSess
         let conn = conn_arc.lock().map_err(|e| e.to_string())?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, title, status, created_at, updated_at FROM agent_sessions ORDER BY updated_at DESC",
+                "SELECT id, title, status, created_at, updated_at, sources, permissions_mode, model_id FROM agent_sessions ORDER BY updated_at DESC",
             )
             .map_err(|e| e.to_string())?;
         let rows = stmt
@@ -57,6 +83,9 @@ pub async fn load_agent_sessions(db: State<'_, AgentDb>) -> Result<Vec<AgentSess
                     status: row.get(2)?,
                     created_at: row.get(3)?,
                     updated_at: row.get(4)?,
+                    sources: row.get(5)?,
+                    permissions_mode: row.get(6)?,
+                    model_id: row.get(7)?,
                 })
             })
             .map_err(|e| e.to_string())?;
@@ -83,6 +112,9 @@ pub fn recover_stuck_sessions(conn: &rusqlite::Connection) -> Result<(), String>
 #[tauri::command]
 pub async fn create_agent_session(
     title: String,
+    sources: Option<String>,
+    permissions_mode: Option<String>,
+    model_id: Option<String>,
     db: State<'_, AgentDb>,
 ) -> Result<AgentSession, String> {
     let conn_arc = db.0.clone();
@@ -94,10 +126,13 @@ pub async fn create_agent_session(
             status: "idle".to_string(),
             created_at: now_ms(),
             updated_at: now_ms(),
+            sources: sources.unwrap_or_else(|| "[]".to_string()),
+            permissions_mode: permissions_mode.unwrap_or_else(|| "Ask".to_string()),
+            model_id,
         };
         conn.execute(
-            "INSERT INTO agent_sessions (id, title, status, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-            rusqlite::params![session.id, session.title, session.status, session.created_at, session.updated_at],
+            "INSERT INTO agent_sessions (id, title, status, created_at, updated_at, sources, permissions_mode, model_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![session.id, session.title, session.status, session.created_at, session.updated_at, session.sources, session.permissions_mode, session.model_id],
         )
         .map_err(|e| format!("Failed to create session: {}", e))?;
         Ok(session)
@@ -223,7 +258,7 @@ pub async fn export_agent_session(
         let conn = conn_arc.lock().map_err(|e| e.to_string())?;
         let session: AgentSession = conn
             .query_row(
-                "SELECT id, title, status, created_at, updated_at FROM agent_sessions WHERE id = ?1",
+                "SELECT id, title, status, created_at, updated_at, sources, permissions_mode, model_id FROM agent_sessions WHERE id = ?1",
                 rusqlite::params![session_id],
                 |row| {
                     Ok(AgentSession {
@@ -232,6 +267,9 @@ pub async fn export_agent_session(
                         status: row.get(2)?,
                         created_at: row.get(3)?,
                         updated_at: row.get(4)?,
+                        sources: row.get(5)?,
+                        permissions_mode: row.get(6)?,
+                        model_id: row.get(7)?,
                     })
                 },
             )
@@ -285,19 +323,33 @@ pub async fn import_agent_session(
             .and_then(|v| v.as_str())
             .unwrap_or("Imported")
             .to_string();
+        let sources = session_in
+            .get("sources")
+            .and_then(|v| v.as_str())
+            .unwrap_or("[]")
+            .to_string();
+        let permissions_mode = session_in
+            .get("permissions_mode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Ask")
+            .to_string();
+        let model_id = session_in.get("model_id").and_then(|v| v.as_str()).map(|s| s.to_string());
         let new_session = AgentSession {
             id: new_id(),
             title,
             status: "idle".to_string(),
             created_at: now_ms(),
             updated_at: now_ms(),
+            sources,
+            permissions_mode,
+            model_id,
         };
 
         let mut conn = conn_arc.lock().map_err(|e| e.to_string())?;
         let tx = conn.transaction().map_err(|e| e.to_string())?;
         tx.execute(
-            "INSERT INTO agent_sessions (id, title, status, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-            rusqlite::params![new_session.id, new_session.title, new_session.status, new_session.created_at, new_session.updated_at],
+            "INSERT INTO agent_sessions (id, title, status, created_at, updated_at, sources, permissions_mode, model_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![new_session.id, new_session.title, new_session.status, new_session.created_at, new_session.updated_at, new_session.sources, new_session.permissions_mode, new_session.model_id],
         )
         .map_err(|e| format!("Failed to insert session: {}", e))?;
 
@@ -316,6 +368,362 @@ pub async fn import_agent_session(
         }
         tx.commit().map_err(|e| e.to_string())?;
         Ok(new_session)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn update_session_meta(
+    session_id: String,
+    sources: Option<String>,
+    permissions_mode: Option<String>,
+    model_id: Option<String>,
+    db: State<'_, AgentDb>,
+) -> Result<(), String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let conn = conn_arc.lock().map_err(|e| e.to_string())?;
+
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut set_clauses: Vec<String> = Vec::new();
+
+        if let Some(ref val) = sources {
+            set_clauses.push(format!("sources = ?{}", params.len() + 1));
+            params.push(Box::new(val.clone()));
+        }
+        if let Some(ref val) = permissions_mode {
+            set_clauses.push(format!("permissions_mode = ?{}", params.len() + 1));
+            params.push(Box::new(val.clone()));
+        }
+        if let Some(ref val) = model_id {
+            set_clauses.push(format!("model_id = ?{}", params.len() + 1));
+            params.push(Box::new(val.clone()));
+        }
+
+        if !set_clauses.is_empty() {
+            set_clauses.push(format!("updated_at = ?{}", params.len() + 1));
+            params.push(Box::new(now_ms()));
+            params.push(Box::new(session_id.clone()));
+            let sql = format!(
+                "UPDATE agent_sessions SET {} WHERE id = ?{}",
+                set_clauses.join(", "),
+                params.len()
+            );
+            conn.execute(&sql, rusqlite::params_from_iter(params.iter().map(|p| p.as_ref())))
+                .map_err(|e| format!("Failed to update session meta: {}", e))?;
+        }
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn load_confirmation_rules(
+    session_id: String,
+    db: State<'_, AgentDb>,
+) -> Result<Vec<ConfirmationRuleRow>, String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<Vec<ConfirmationRuleRow>, String> {
+        let conn = conn_arc.lock().map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, tool_name, action, created_at FROM confirmation_rules WHERE session_id = ?1 ORDER BY created_at ASC",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map(rusqlite::params![session_id], |row| {
+                Ok(ConfirmationRuleRow {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    tool_name: row.get(2)?,
+                    action: row.get(3)?,
+                    created_at: row.get(4)?,
+                })
+            })
+            .map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(|e| e.to_string())?);
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn save_confirmation_rule(
+    session_id: String,
+    tool_name: String,
+    action: String,
+    db: State<'_, AgentDb>,
+) -> Result<ConfirmationRuleRow, String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<ConfirmationRuleRow, String> {
+        let conn = conn_arc.lock().map_err(|e| e.to_string())?;
+        let row = ConfirmationRuleRow {
+            id: new_id(),
+            session_id,
+            tool_name,
+            action,
+            created_at: now_ms(),
+        };
+        conn.execute(
+            "INSERT OR REPLACE INTO confirmation_rules (id, session_id, tool_name, action, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![row.id, row.session_id, row.tool_name, row.action, row.created_at],
+        )
+        .map_err(|e| format!("Failed to save confirmation rule: {}", e))?;
+        Ok(row)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn delete_confirmation_rule(
+    id: String,
+    db: State<'_, AgentDb>,
+) -> Result<(), String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let conn = conn_arc.lock().map_err(|e| e.to_string())?;
+        conn.execute(
+            "DELETE FROM confirmation_rules WHERE id = ?1",
+            rusqlite::params![id],
+        )
+        .map_err(|e| format!("Failed to delete confirmation rule: {}", e))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn clear_session_confirmation_rules(
+    session_id: String,
+    db: State<'_, AgentDb>,
+) -> Result<(), String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let conn = conn_arc.lock().map_err(|e| e.to_string())?;
+        conn.execute(
+            "DELETE FROM confirmation_rules WHERE session_id = ?1",
+            rusqlite::params![session_id],
+        )
+        .map_err(|e| format!("Failed to clear confirmation rules: {}", e))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn load_attached_sources(
+    db: State<'_, AgentDb>,
+) -> Result<Vec<AttachedSourceRow>, String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<Vec<AttachedSourceRow>, String> {
+        let conn = conn_arc.lock().map_err(|e| e.to_string())?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, kind, alias, name, database_type, file_type, file_path, connection_id, created_at, updated_at FROM attached_sources ORDER BY created_at ASC",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(AttachedSourceRow {
+                    id: row.get(0)?,
+                    kind: row.get(1)?,
+                    alias: row.get(2)?,
+                    name: row.get(3)?,
+                    database_type: row.get(4)?,
+                    file_type: row.get(5)?,
+                    file_path: row.get(6)?,
+                    connection_id: row.get(7)?,
+                    created_at: row.get(8)?,
+                    updated_at: row.get(9)?,
+                })
+            })
+            .map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(|e| e.to_string())?);
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn save_attached_source(
+    id: String,
+    kind: String,
+    alias: Option<String>,
+    name: Option<String>,
+    database_type: Option<String>,
+    file_type: Option<String>,
+    file_path: Option<String>,
+    connection_id: Option<i64>,
+    created_at: Option<i64>,
+    updated_at: Option<i64>,
+    db: State<'_, AgentDb>,
+) -> Result<AttachedSourceRow, String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<AttachedSourceRow, String> {
+        let conn = conn_arc.lock().map_err(|e| e.to_string())?;
+        let now = now_ms();
+        // If created_at is not provided, preserve the existing value from DB
+        // (for updates) or use current time for genuinely new rows.
+        let resolved_created_at = if created_at.is_none() {
+            conn.query_row(
+                "SELECT created_at FROM attached_sources WHERE id = ?1",
+                rusqlite::params![&id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_or(now)
+        } else {
+            created_at.unwrap()
+        };
+        let row = AttachedSourceRow {
+            id,
+            kind,
+            alias,
+            name,
+            database_type,
+            file_type,
+            file_path,
+            connection_id,
+            created_at: resolved_created_at,
+            updated_at: updated_at.unwrap_or(now),
+        };
+        conn.execute(
+            "INSERT OR REPLACE INTO attached_sources (id, kind, alias, name, database_type, file_type, file_path, connection_id, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            rusqlite::params![row.id, row.kind, row.alias, row.name, row.database_type, row.file_type, row.file_path, row.connection_id, row.created_at, row.updated_at],
+        )
+        .map_err(|e| format!("Failed to save attached source: {}", e))?;
+        Ok(row)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn delete_attached_source(
+    id: String,
+    db: State<'_, AgentDb>,
+) -> Result<(), String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let conn = conn_arc.lock().map_err(|e| e.to_string())?;
+        conn.execute(
+            "DELETE FROM attached_sources WHERE id = ?1",
+            rusqlite::params![id],
+        )
+        .map_err(|e| format!("Failed to delete attached source: {}", e))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn migrate_session_metadata(
+    session_meta: String,
+    confirmation_rules: String,
+    attached_sources: String,
+    db: State<'_, AgentDb>,
+) -> Result<(), String> {
+    let conn_arc = db.0.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let mut conn = conn_arc.lock().map_err(|e| e.to_string())?;
+        let tx = conn.transaction().map_err(|e| e.to_string())?;
+
+        // Parse session_meta — Record<string, {sources, permissionsMode, maxIterations, title, updatedAt, modelId}>
+        let meta: Value = serde_json::from_str(&session_meta).map_err(|e| e.to_string())?;
+        if let Value::Object(map) = &meta {
+            for (session_id, fields) in map {
+                let now = now_ms();
+                if let Value::Object(field_map) = fields {
+                    let sources = field_map.get("sources").and_then(|v| v.as_str()).unwrap_or("[]");
+                    let permissions_mode = field_map.get("permissionsMode").and_then(|v| v.as_str()).unwrap_or("Ask");
+                    let model_id = field_map.get("modelId").and_then(|v| v.as_str());
+
+                    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+                    let mut set_clauses: Vec<String> = Vec::new();
+
+                    set_clauses.push(format!("sources = ?{}", params.len() + 1));
+                    params.push(Box::new(sources.to_string()));
+                    set_clauses.push(format!("permissions_mode = ?{}", params.len() + 1));
+                    params.push(Box::new(permissions_mode.to_string()));
+                    set_clauses.push(format!("updated_at = ?{}", params.len() + 1));
+                    params.push(Box::new(now));
+
+                    if let Some(mid) = model_id {
+                        set_clauses.push(format!("model_id = ?{}", params.len() + 1));
+                        params.push(Box::new(mid.to_string()));
+                    } else {
+                        set_clauses.push("model_id = NULL".to_string());
+                    }
+
+                    let sid = session_id.clone();
+                    let sql = format!(
+                        "UPDATE agent_sessions SET {} WHERE id = ?{}",
+                        set_clauses.join(", "),
+                        params.len() + 1
+                    );
+                    params.push(Box::new(sid));
+                    tx.execute(&sql, rusqlite::params_from_iter(params.iter().map(|p| p.as_ref())))
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+        }
+
+        // Parse confirmation_rules — Array<{sessionId, toolName, action}>
+        let rules: Value = serde_json::from_str(&confirmation_rules).map_err(|e| e.to_string())?;
+        if let Value::Array(arr) = &rules {
+            for entry in arr {
+                if let Value::Object(obj) = entry {
+                    let sid = obj.get("sessionId").and_then(|v| v.as_str()).unwrap_or("");
+                    let tool = obj.get("toolName").and_then(|v| v.as_str()).unwrap_or("");
+                    let action = obj.get("action").and_then(|v| v.as_str()).unwrap_or("");
+                    tx.execute(
+                        "INSERT INTO confirmation_rules (id, session_id, tool_name, action, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+                        rusqlite::params![new_id(), sid, tool, action, now_ms()],
+                    )
+                    .map_err(|e| format!("Failed to insert confirmation rule: {}", e))?;
+                }
+            }
+        }
+
+        // Parse attached_sources — Array<{id, kind, alias, name, databaseType, fileType, filePath, connectionId}>
+        let sources_val: Value = serde_json::from_str(&attached_sources).map_err(|e| e.to_string())?;
+        if let Value::Array(arr) = &sources_val {
+            for entry in arr {
+                if let Value::Object(obj) = entry {
+                    let id = obj.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                    let kind = obj.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+                    let alias = obj.get("alias").and_then(|v| v.as_str());
+                    let name = obj.get("name").and_then(|v| v.as_str());
+                    let database_type = obj.get("databaseType").and_then(|v| v.as_str());
+                    let file_type = obj.get("fileType").and_then(|v| v.as_str());
+                    let file_path = obj.get("filePath").and_then(|v| v.as_str());
+                    let connection_id = obj.get("connectionId").and_then(|v| v.as_i64());
+                    let now = now_ms();
+                    tx.execute(
+                        "INSERT OR REPLACE INTO attached_sources (id, kind, alias, name, database_type, file_type, file_path, connection_id, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                        rusqlite::params![id, kind, alias, name, database_type, file_type, file_path, connection_id, now, now],
+                    )
+                    .map_err(|e| format!("Failed to insert attached source: {}", e))?;
+                }
+            }
+        }
+
+        tx.commit().map_err(|e| e.to_string())?;
+        Ok(())
     })
     .await
     .map_err(|e| e.to_string())?

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -20,10 +20,19 @@ pub fn open(path: &Path) -> Result<AgentDb, String> {
     Ok(AgentDb(Arc::new(Mutex::new(conn))))
 }
 
+pub fn get_schema_version(db: &AgentDb) -> Result<i32, String> {
+    let conn =
+        db.0.lock()
+            .map_err(|e| format!("Failed to lock db: {}", e))?;
+    conn.query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|e| format!("Failed to read user_version: {}", e))
+}
+
 pub fn migrate(db: &AgentDb) -> Result<(), String> {
     let conn =
         db.0.lock()
             .map_err(|e| format!("Failed to lock db: {}", e))?;
+
     conn.execute_batch(
         r#"
         CREATE TABLE IF NOT EXISTS agent_sessions (
@@ -83,6 +92,59 @@ pub fn migrate(db: &AgentDb) -> Result<(), String> {
         DELETE FROM query_history WHERE connection_id IS NULL;
         "#,
     )
-    .map_err(|e| format!("Failed to migrate db: {}", e))?;
+    .map_err(|e| format!("Failed to create initial tables: {}", e))?;
+
+    let current_version: i32 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|e| format!("Failed to read user_version: {}", e))?;
+
+    if current_version < 1 {
+        // Individual ALTER TABLE calls so a partially-applied migration
+        // (column already exists) does not abort the whole batch.
+        let alter_statements = [
+            "ALTER TABLE agent_sessions ADD COLUMN sources TEXT NOT NULL DEFAULT '[]'",
+            "ALTER TABLE agent_sessions ADD COLUMN permissions_mode TEXT NOT NULL DEFAULT 'Ask'",
+            "ALTER TABLE agent_sessions ADD COLUMN model_id TEXT",
+        ];
+
+        for stmt in &alter_statements {
+            if let Err(e) = conn.execute(stmt, []) {
+                // Likely "duplicate column" — the column was already added
+                // by a previous partial migration. Log and continue.
+                eprintln!("[db/migrate] warning (column may already exist): {e}");
+            }
+        }
+
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS confirmation_rules (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                tool_name TEXT NOT NULL,
+                action TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                FOREIGN KEY (session_id) REFERENCES agent_sessions(id) ON DELETE CASCADE,
+                UNIQUE(session_id, tool_name)
+            );
+            CREATE TABLE IF NOT EXISTS attached_sources (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                alias TEXT,
+                name TEXT,
+                database_type TEXT,
+                file_type TEXT,
+                file_path TEXT,
+                connection_id INTEGER,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );
+            "#,
+        )
+        .map_err(|e| format!("Failed to create version-1 tables: {e}"))?;
+
+        conn.execute_batch("PRAGMA user_version = 1;")
+            .map_err(|e| format!("Failed to set user_version: {e}"))?;
+    }
+
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,9 +27,11 @@ use agent::query_history::{
     load_query_history, toggle_query_history_star,
 };
 use agent::session_store::{
-    clear_agent_session_messages, create_agent_session, delete_agent_session, export_agent_session,
-    import_agent_session, load_agent_sessions, load_session_messages, recover_stuck_sessions,
-    update_session_status,
+    clear_agent_session_messages, clear_session_confirmation_rules, create_agent_session,
+    delete_agent_session, delete_attached_source, delete_confirmation_rule, export_agent_session,
+    import_agent_session, load_agent_sessions, load_attached_sources, load_confirmation_rules,
+    load_session_messages, migrate_session_metadata, recover_stuck_sessions,
+    save_attached_source, save_confirmation_rule, update_session_meta, update_session_status,
 };
 use agent::tool_executor::ToolExecutor;
 use agent::{
@@ -131,11 +133,20 @@ pub fn run() {
             load_agent_sessions,
             create_agent_session,
             update_session_status,
+            update_session_meta,
             delete_agent_session,
             clear_agent_session_messages,
             load_session_messages,
             export_agent_session,
             import_agent_session,
+            load_confirmation_rules,
+            save_confirmation_rule,
+            delete_confirmation_rule,
+            clear_session_confirmation_rules,
+            load_attached_sources,
+            save_attached_source,
+            delete_attached_source,
+            migrate_session_metadata,
             load_query_history,
             add_query_history_entry,
             toggle_query_history_star,

--- a/src/composables/useChatAgent.ts
+++ b/src/composables/useChatAgent.ts
@@ -455,7 +455,6 @@ export const useChatAgent = (config: UseChatAgentConfig) => {
 
     if (action === 'allow_always' && config.addConfirmationRule) {
       config.addConfirmationRule({
-        id: ulid(),
         sessionId: session.id,
         toolName: toolCall.toolName,
         action: 'allow_always',
@@ -463,7 +462,6 @@ export const useChatAgent = (config: UseChatAgentConfig) => {
     }
     if (action === 'deny_always' && config.addConfirmationRule) {
       config.addConfirmationRule({
-        id: ulid(),
         sessionId: session.id,
         toolName: toolCall.toolName,
         action: 'deny_always',

--- a/src/composables/useChatAgent.ts
+++ b/src/composables/useChatAgent.ts
@@ -455,6 +455,7 @@ export const useChatAgent = (config: UseChatAgentConfig) => {
 
     if (action === 'allow_always' && config.addConfirmationRule) {
       config.addConfirmationRule({
+        id: ulid(),
         sessionId: session.id,
         toolName: toolCall.toolName,
         action: 'allow_always',
@@ -462,6 +463,7 @@ export const useChatAgent = (config: UseChatAgentConfig) => {
     }
     if (action === 'deny_always' && config.addConfirmationRule) {
       config.addConfirmationRule({
+        id: ulid(),
         sessionId: session.id,
         toolName: toolCall.toolName,
         action: 'deny_always',

--- a/src/composables/useDataStudioChatAgent.ts
+++ b/src/composables/useDataStudioChatAgent.ts
@@ -11,6 +11,7 @@ import {
   type SessionSource,
 } from '@/store/dataStudioStore';
 import { useConnectionStore } from '@/store/connectionStore';
+import { useAppStore } from '@/store/appStore';
 import { useChatAgent, type UseChatAgentConfig } from './useChatAgent';
 import type {
   ChatMessage,
@@ -42,7 +43,7 @@ const adaptDataStudioSession = (session: AgentSession): ChatSession => ({
   status: session.status as ChatSessionStatus,
   sources: session.sources,
   permissionsMode: session.permissionsMode,
-  maxIterations: session.maxIterations,
+  maxIterations: useAppStore().chatConfig.maxIterations,
   stopReason: session.stopReason,
   stopMessage: session.stopMessage,
 });

--- a/src/composables/useSidebarChatAgent.ts
+++ b/src/composables/useSidebarChatAgent.ts
@@ -8,6 +8,7 @@ import {
   type AgentMessage,
   type ConfirmationRule,
 } from '@/store/dataStudioStore';
+import { useAppStore } from '@/store/appStore';
 import { useTabStore } from '@/store/tabStore';
 import { DatabaseType, type ElasticsearchConnection } from '@/store/connectionStore';
 import { useChatAgent, type UseChatAgentConfig } from './useChatAgent';
@@ -41,7 +42,7 @@ const adaptSession = (session: AgentSession): ChatSession => ({
   messages: session.messages.map(adaptMessage),
   status: session.status as ChatSessionStatus,
   sources: session.sources,
-  maxIterations: session.maxIterations,
+  maxIterations: useAppStore().chatConfig.maxIterations,
   stopReason: session.stopReason,
   stopMessage: session.stopMessage,
 });

--- a/src/datasources/agentApi.ts
+++ b/src/datasources/agentApi.ts
@@ -40,6 +40,9 @@ export type AgentSession = {
   id: string;
   title: string;
   status: 'idle' | 'running' | 'error';
+  sources: string;
+  permissions_mode: string;
+  model_id: string | null;
   created_at: number;
   updated_at: number;
 };
@@ -114,6 +117,27 @@ export type MultiSourceToolPermissions = {
   delete: boolean;
 };
 
+export type AttachedSourceRow = {
+  id: string;
+  kind: string;
+  alias: string | null;
+  name: string | null;
+  database_type: string | null;
+  file_type: string | null;
+  file_path: string | null;
+  connection_id: number | null;
+  created_at: number;
+  updated_at: number;
+};
+
+export type ConfirmationRuleRow = {
+  id: string;
+  session_id: string;
+  tool_name: string;
+  action: string;
+  created_at: number;
+};
+
 const agentApi = {
   runAgentStep: async (params: {
     requestId: string;
@@ -169,8 +193,18 @@ const deleteQueryHistoryEntry = (id: string) => invoke<void>('delete_query_histo
 const clearQueryHistory = () => invoke<void>('clear_query_history');
 
 const loadAgentSessions = () => invoke<AgentSession[]>('load_agent_sessions');
-const createAgentSession = (title: string) =>
-  invoke<AgentSession>('create_agent_session', { title });
+const createAgentSession = (
+  title: string,
+  sources?: string,
+  permissionsMode?: string,
+  modelId?: string | null,
+) => {
+  const args: Record<string, unknown> = { title };
+  if (sources !== undefined) args.sources = sources;
+  if (permissionsMode !== undefined) args.permissionsMode = permissionsMode;
+  if (modelId !== undefined) args.modelId = modelId;
+  return invoke<AgentSession>('create_agent_session', args);
+};
 const updateSessionStatus = (sessionId: string, status: string) =>
   invoke<void>('update_session_status', { sessionId, status });
 const deleteAgentSession = (sessionId: string) =>
@@ -200,6 +234,47 @@ const confirmToolCall = (toolCallId: string, allowed: boolean) =>
   invoke<void>('confirm_tool_call', { toolCallId, allowed });
 const getToolFullResult = (toolCallId: string) =>
   invoke<string>('get_tool_full_result', { toolCallId });
+
+const updateSessionMeta = async (
+  sessionId: string,
+  sources?: string,
+  permissionsMode?: string,
+  modelId?: string | null,
+): Promise<void> => {
+  const args: Record<string, unknown> = { sessionId };
+  if (sources !== undefined) args.sources = sources;
+  if (permissionsMode !== undefined) args.permissionsMode = permissionsMode;
+  if (modelId !== undefined) args.modelId = modelId;
+  await invoke<void>('update_session_meta', args);
+};
+
+const loadConfirmationRules = (sessionId: string) =>
+  invoke<ConfirmationRuleRow[]>('load_confirmation_rules', { sessionId });
+
+const saveConfirmationRule = (sessionId: string, toolName: string, action: string) =>
+  invoke<ConfirmationRuleRow>('save_confirmation_rule', { sessionId, toolName, action });
+
+const deleteConfirmationRule = (id: string) => invoke<void>('delete_confirmation_rule', { id });
+
+const clearSessionConfirmationRules = (sessionId: string) =>
+  invoke<void>('clear_session_confirmation_rules', { sessionId });
+
+const loadAttachedSources = () => invoke<AttachedSourceRow[]>('load_attached_sources');
+
+const saveAttachedSource = (
+  fields: Omit<AttachedSourceRow, 'created_at' | 'updated_at'> & {
+    created_at?: number;
+    updated_at?: number;
+  },
+) => invoke<AttachedSourceRow>('save_attached_source', fields);
+
+const deleteAttachedSource = (id: string) => invoke<void>('delete_attached_source', { id });
+
+const migrateSessionMetadata = (
+  sessionMeta: string,
+  confirmationRules: string,
+  attachedSources: string,
+) => invoke<void>('migrate_session_metadata', { sessionMeta, confirmationRules, attachedSources });
 
 const onAgentLoopDelta = (handler: (payload: { session_id: string; content: string }) => void) =>
   listen('agent-loop-delta', e => handler(e.payload as { session_id: string; content: string }));
@@ -309,6 +384,15 @@ export {
   cancelAgentLoop,
   confirmToolCall,
   getToolFullResult,
+  updateSessionMeta,
+  loadConfirmationRules,
+  saveConfirmationRule,
+  deleteConfirmationRule,
+  clearSessionConfirmationRules,
+  loadAttachedSources,
+  saveAttachedSource,
+  deleteAttachedSource,
+  migrateSessionMetadata,
   compactAgentSession,
   getAgentContextUsage,
   onAgentLoopDelta,

--- a/src/store/dataStudioStore.ts
+++ b/src/store/dataStudioStore.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { defineStore } from 'pinia';
 import { ulid } from 'ulidx';
 import {
@@ -144,7 +145,7 @@ export type AgentSession = {
 };
 
 export type ConfirmationRule = {
-  id: string;
+  id?: string; // optional — backend generates ID on create, present when loaded from DB
   sessionId: string; // scoped to a session, not a source
   toolName: string; // bare tool name without alias prefix
   action: 'allow_always' | 'deny_always';
@@ -434,12 +435,12 @@ export const useDataStudioStore = defineStore('dataStudio', {
     },
 
     // ── Backward compat: create a DatabaseSource from a connectionId + Connection ──
-    addDatabaseSourceFromConnection(params: {
+    async addDatabaseSourceFromConnection(params: {
       connectionId: number;
       name: string;
       databaseType: 'ELASTICSEARCH' | 'OPENSEARCH' | 'EASYSEARCH' | 'DYNAMODB' | 'MONGODB';
       permissions: DataSourcePermissions;
-    }): DatabaseSource {
+    }): Promise<DatabaseSource> {
       const existing = this.attachedSources.find(
         s => s.kind === 'database' && (s as DatabaseSource).connectionId === params.connectionId,
       ) as DatabaseSource | undefined;
@@ -460,7 +461,7 @@ export const useDataStudioStore = defineStore('dataStudio', {
         permissions: params.permissions,
       };
       this.attachedSources = [...this.attachedSources, source];
-      saveAttachedSource({
+      await saveAttachedSource({
         id: source.sourceId,
         kind: 'database',
         alias: source.name,
@@ -471,7 +472,7 @@ export const useDataStudioStore = defineStore('dataStudio', {
         connection_id: source.connectionId,
         created_at: Date.now(),
         updated_at: Date.now(),
-      }).catch(() => {});
+      });
       return source;
     },
 
@@ -482,7 +483,9 @@ export const useDataStudioStore = defineStore('dataStudio', {
       if (!session) return false;
       const updated = attachSourceToSession(session, source);
       this.sessions = this.sessions.map(s => (s.id === session.id ? updated : s));
-      await updateSessionMeta(session.id, JSON.stringify(updated.sources)).catch(() => {});
+      await updateSessionMeta(session.id, JSON.stringify(updated.sources)).catch(e =>
+        console.warn('[persist] updateSessionMeta failed:', e),
+      );
       return true;
     },
 
@@ -495,7 +498,9 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, sources: updatedSources } : s,
       );
-      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(() => {});
+      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(e =>
+        console.warn('[persist] updateSessionMeta failed:', e),
+      );
     },
 
     async setSessionPermissionsMode(sessionId: string, mode: PermissionsMode) {
@@ -516,7 +521,9 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, permissionsMode: mode, sources: updatedSources } : s,
       );
-      await updateSessionMeta(sessionId, JSON.stringify(updatedSources), mode).catch(() => {});
+      await updateSessionMeta(sessionId, JSON.stringify(updatedSources), mode).catch(e =>
+        console.warn('[persist] updateSessionMeta failed:', e),
+      );
     },
 
     async updateSessionSourcePermissions(
@@ -530,7 +537,9 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, sources: updatedSources } : s,
       );
-      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(() => {});
+      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(e =>
+        console.warn('[persist] updateSessionMeta failed:', e),
+      );
     },
 
     async updateSessionSourceMode(
@@ -558,7 +567,9 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, sources: updatedSources } : s,
       );
-      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(() => {});
+      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(e =>
+        console.warn('[persist] updateSessionMeta failed:', e),
+      );
     },
 
     // ── One-time migration from localStorage to SQLite ─────────────────────
@@ -956,7 +967,9 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, model_id: modelId } : s,
       );
-      await updateSessionMeta(sessionId, undefined, undefined, modelId).catch(() => {});
+      await updateSessionMeta(sessionId, undefined, undefined, modelId).catch(e =>
+        console.warn('[persist] updateSessionMeta failed:', e),
+      );
     },
 
     async reloadSessionMessages(sessionId: string) {

--- a/src/store/dataStudioStore.ts
+++ b/src/store/dataStudioStore.ts
@@ -7,6 +7,14 @@ import {
   loadAgentSessions,
   loadSessionMessages,
   updateSessionStatus,
+  updateSessionMeta,
+  loadConfirmationRules,
+  saveConfirmationRule,
+  deleteConfirmationRule,
+  loadAttachedSources,
+  saveAttachedSource,
+  deleteAttachedSource,
+  migrateSessionMetadata,
   type AgentSession as BackendAgentSession,
   type AgentMessage as BackendAgentMessage,
 } from '../datasources/agentApi';
@@ -123,28 +131,23 @@ export type AgentSessionStopReason =
 
 export type AgentSession = {
   id: string;
+  title: string; // from backend
   sources: SessionSource[]; // ordered snapshots; records are permanent once added
   permissionsMode: PermissionsMode; // session-level — applies uniformly to all sources
   messages: Array<AgentMessage>;
   status: AgentSessionStatus;
-  maxIterations: number;
   stopReason?: AgentSessionStopReason;
   stopMessage?: string;
+  updated_at: number; // from backend AgentSession
+  created_at: number; // from backend AgentSession
+  model_id: string | null; // from backend agent_sessions.model_id
 };
 
 export type ConfirmationRule = {
+  id: string;
   sessionId: string; // scoped to a session, not a source
   toolName: string; // bare tool name without alias prefix
   action: 'allow_always' | 'deny_always';
-};
-
-export type SessionMeta = {
-  sources: SessionSource[];
-  permissionsMode: PermissionsMode;
-  maxIterations: number;
-  title: string;
-  updatedAt: number;
-  modelId?: string | null;
 };
 
 // ── Alias derivation ─────────────────────────────────────────────────────────
@@ -319,7 +322,6 @@ export const useDataStudioStore = defineStore('dataStudio', {
     activeSessionId: string | undefined;
     sidebarSessionId: string | undefined;
     confirmationRules: Array<ConfirmationRule>;
-    sessionMeta: Record<string, SessionMeta>;
     toolResultFullBodies: Record<string, string>;
     sessionErrors: Record<string, string>;
     sessionProgress: Record<string, SessionProgress>;
@@ -329,19 +331,12 @@ export const useDataStudioStore = defineStore('dataStudio', {
     activeSessionId: undefined,
     sidebarSessionId: undefined,
     confirmationRules: [],
-    sessionMeta: {},
     toolResultFullBodies: {},
     sessionErrors: {},
     sessionProgress: {},
   }),
   persist: {
-    pick: [
-      'attachedSources',
-      'confirmationRules',
-      'sessionMeta',
-      'activeSessionId',
-      'sidebarSessionId',
-    ],
+    pick: ['activeSessionId', 'sidebarSessionId'],
   },
   getters: {
     activeSession(state): AgentSession | undefined {
@@ -356,28 +351,86 @@ export const useDataStudioStore = defineStore('dataStudio', {
   actions: {
     // ── Attached source management ──────────────────────────────────────────
 
-    addAttachedSource(source: AttachedSource): boolean {
+    async addAttachedSource(source: AttachedSource): Promise<boolean> {
       const exists = this.attachedSources.some(s => s.sourceId === source.sourceId);
       if (exists) return false;
+
+      await saveAttachedSource({
+        id: source.sourceId,
+        kind: source.kind,
+        alias: source.name,
+        name: source.name,
+        database_type: source.kind === 'database' ? (source as DatabaseSource).databaseType : null,
+        file_type: source.kind === 'file' ? (source as FileSource).fileType : null,
+        file_path: source.kind === 'file' ? (source as FileSource).filePath : null,
+        connection_id: source.kind === 'database' ? (source as DatabaseSource).connectionId : null,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      });
+
       this.attachedSources = [...this.attachedSources, source];
       return true;
     },
 
-    updateAttachedSource(
+    async updateAttachedSource(
       sourceId: string,
       patch: Partial<Omit<AttachedSource, 'sourceId' | 'kind'>>,
     ) {
       this.attachedSources = this.attachedSources.map(s =>
         s.sourceId === sourceId ? ({ ...s, ...patch } as AttachedSource) : s,
       );
+      const updated = this.attachedSources.find(s => s.sourceId === sourceId);
+      if (updated) {
+        await saveAttachedSource({
+          id: updated.sourceId,
+          kind: updated.kind,
+          alias: updated.name,
+          name: updated.name,
+          database_type:
+            updated.kind === 'database' ? (updated as DatabaseSource).databaseType : null,
+          file_type: updated.kind === 'file' ? (updated as FileSource).fileType : null,
+          file_path: updated.kind === 'file' ? (updated as FileSource).filePath : null,
+          connection_id:
+            updated.kind === 'database' ? (updated as DatabaseSource).connectionId : null,
+          created_at: undefined, // preserve existing DB value
+          updated_at: Date.now(),
+        });
+      }
     },
 
-    removeAttachedSource(sourceId: string) {
+    async removeAttachedSource(sourceId: string) {
       this.attachedSources = this.attachedSources.filter(s => s.sourceId !== sourceId);
+      await deleteAttachedSource(sourceId);
     },
 
     getAttachedSourceById(sourceId: string): AttachedSource | undefined {
       return this.attachedSources.find(s => s.sourceId === sourceId);
+    },
+
+    async loadAttachedSourcesFromDb(): Promise<void> {
+      const rows = await loadAttachedSources();
+      this.attachedSources = rows.map(row => {
+        const base = {
+          sourceId: row.id,
+          name: row.name ?? '',
+        };
+        if (row.kind === 'database') {
+          return {
+            ...base,
+            kind: 'database' as const,
+            connectionId: row.connection_id ?? 0,
+            databaseType: (row.database_type ?? 'ELASTICSEARCH') as DatabaseSource['databaseType'],
+            permissions: { read: true, create: false, update: false, delete: false },
+          } as DatabaseSource;
+        }
+        return {
+          ...base,
+          kind: 'file' as const,
+          fileType: (row.file_type ?? 'json') as FileSource['fileType'],
+          filePath: row.file_path ?? '',
+          permissions: { read: true },
+        } as FileSource;
+      });
     },
 
     // ── Backward compat: create a DatabaseSource from a connectionId + Connection ──
@@ -407,23 +460,33 @@ export const useDataStudioStore = defineStore('dataStudio', {
         permissions: params.permissions,
       };
       this.attachedSources = [...this.attachedSources, source];
+      saveAttachedSource({
+        id: source.sourceId,
+        kind: 'database',
+        alias: source.name,
+        name: source.name,
+        database_type: source.databaseType,
+        file_type: null,
+        file_path: null,
+        connection_id: source.connectionId,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      }).catch(() => {});
       return source;
     },
 
     // ── Session source management ────────────────────────────────────────────
 
-    attachSourceToActiveSession(source: AttachedSource): boolean {
+    async attachSourceToActiveSession(source: AttachedSource): Promise<boolean> {
       const session = this.activeSession;
       if (!session) return false;
       const updated = attachSourceToSession(session, source);
       this.sessions = this.sessions.map(s => (s.id === session.id ? updated : s));
-      if (this.sessionMeta[session.id]) {
-        this.sessionMeta[session.id].sources = updated.sources;
-      }
+      await updateSessionMeta(session.id, JSON.stringify(updated.sources)).catch(() => {});
       return true;
     },
 
-    detachSourceFromSession(sessionId: string, sourceId: string) {
+    async detachSourceFromSession(sessionId: string, sourceId: string) {
       const session = this.sessions.find(s => s.id === sessionId);
       if (!session) return;
       const updatedSources = session.sources.map(s =>
@@ -432,12 +495,10 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, sources: updatedSources } : s,
       );
-      if (this.sessionMeta[sessionId]) {
-        this.sessionMeta[sessionId].sources = updatedSources;
-      }
+      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(() => {});
     },
 
-    setSessionPermissionsMode(sessionId: string, mode: PermissionsMode) {
+    async setSessionPermissionsMode(sessionId: string, mode: PermissionsMode) {
       const writePerms = mode === 'Auto';
       const updatedSources = (this.sessions.find(s => s.id === sessionId)?.sources ?? []).map(s =>
         s.detached || s.permissionsMode === 'custom'
@@ -455,13 +516,10 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, permissionsMode: mode, sources: updatedSources } : s,
       );
-      if (this.sessionMeta[sessionId]) {
-        this.sessionMeta[sessionId].permissionsMode = mode;
-        this.sessionMeta[sessionId].sources = updatedSources;
-      }
+      await updateSessionMeta(sessionId, JSON.stringify(updatedSources), mode).catch(() => {});
     },
 
-    updateSessionSourcePermissions(
+    async updateSessionSourcePermissions(
       sessionId: string,
       sourceId: string,
       permissions: DataSourcePermissions,
@@ -472,12 +530,14 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, sources: updatedSources } : s,
       );
-      if (this.sessionMeta[sessionId]) {
-        this.sessionMeta[sessionId].sources = updatedSources;
-      }
+      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(() => {});
     },
 
-    updateSessionSourceMode(sessionId: string, sourceId: string, mode: SourcePermissionsMode) {
+    async updateSessionSourceMode(
+      sessionId: string,
+      sourceId: string,
+      mode: SourcePermissionsMode,
+    ) {
       const session = this.sessions.find(s => s.id === sessionId);
       const writePerms = session?.permissionsMode === 'Auto';
       const inheritedPermissions: DataSourcePermissions = {
@@ -498,8 +558,36 @@ export const useDataStudioStore = defineStore('dataStudio', {
       this.sessions = this.sessions.map(s =>
         s.id === sessionId ? { ...s, sources: updatedSources } : s,
       );
-      if (this.sessionMeta[sessionId]) {
-        this.sessionMeta[sessionId].sources = updatedSources;
+      await updateSessionMeta(sessionId, JSON.stringify(updatedSources)).catch(() => {});
+    },
+
+    // ── One-time migration from localStorage to SQLite ─────────────────────
+
+    async migrateFromLocalStorage(): Promise<void> {
+      try {
+        const raw = localStorage.getItem('dataStudio');
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        const hasMeta = parsed?.sessionMeta && Object.keys(parsed.sessionMeta).length > 0;
+        const hasRules = parsed?.confirmationRules?.length > 0;
+        const hasSources = parsed?.attachedSources?.length > 0;
+        if (!hasMeta && !hasRules && !hasSources) return;
+
+        await migrateSessionMetadata(
+          JSON.stringify(parsed.sessionMeta ?? {}),
+          JSON.stringify(parsed.confirmationRules ?? []),
+          JSON.stringify(parsed.attachedSources ?? []),
+        );
+
+        const state = { ...parsed };
+        delete state.sessionMeta;
+        delete state.confirmationRules;
+        delete state.attachedSources;
+        localStorage.setItem('dataStudio', JSON.stringify(state));
+
+        await this.loadAttachedSourcesFromDb();
+      } catch (e) {
+        console.error('[migrateFromLocalStorage] Migration failed:', e);
       }
     },
 
@@ -508,28 +596,26 @@ export const useDataStudioStore = defineStore('dataStudio', {
     async createSession(
       initialSources: SessionSource[] = [],
       permissionsMode: PermissionsMode = 'Ask',
-      maxIterations = 10,
       setActive = true,
+      title?: string,
     ): Promise<string> {
-      const title =
-        initialSources.length > 0 ? initialSources.map(s => s.alias).join(', ') : 'New Session';
-      const backend = await createAgentSession(title);
+      const sessionTitle =
+        title ??
+        (initialSources.length > 0 ? initialSources.map(s => s.alias).join(', ') : 'New Session');
+      const sourcesJson = JSON.stringify(initialSources);
+      const backend = await createAgentSession(sessionTitle, sourcesJson, permissionsMode, null);
       const newSession: AgentSession = {
         id: backend.id,
+        title: backend.title,
         sources: initialSources,
         permissionsMode,
         messages: [],
         status: 'idle',
-        maxIterations,
+        updated_at: backend.updated_at,
+        created_at: backend.created_at,
+        model_id: backend.model_id,
       };
       this.sessions = [...this.sessions, newSession];
-      this.sessionMeta[backend.id] = {
-        sources: initialSources,
-        permissionsMode,
-        maxIterations,
-        title,
-        updatedAt: backend.updated_at,
-      };
       if (setActive) this.activeSessionId = backend.id;
       return backend.id;
     },
@@ -549,11 +635,14 @@ export const useDataStudioStore = defineStore('dataStudio', {
       for (const source of sourcesToAttach) {
         const tmpSession: AgentSession = {
           id: '',
+          title: '',
           sources: sessionSources,
           permissionsMode: 'Ask',
           messages: [],
           status: 'idle',
-          maxIterations: 10,
+          updated_at: 0,
+          created_at: 0,
+          model_id: null,
         };
         const updated = attachSourceToSession(tmpSession, source);
         sessionSources.push(...updated.sources.slice(sessionSources.length));
@@ -566,7 +655,7 @@ export const useDataStudioStore = defineStore('dataStudio', {
       if (this.sidebarSessionId && this.sessions.some(s => s.id === this.sidebarSessionId)) {
         return this.sidebarSessionId;
       }
-      const id = await this.createSession([], 'Ask', 10, false);
+      const id = await this.createSession([], 'Ask', false);
       this.sidebarSessionId = id;
       return id;
     },
@@ -863,17 +952,11 @@ export const useDataStudioStore = defineStore('dataStudio', {
       );
     },
 
-    setSessionMaxIterations(sessionId: string, maxIterations: number) {
-      this.sessions = this.sessions.map(s => (s.id === sessionId ? { ...s, maxIterations } : s));
-      if (this.sessionMeta[sessionId]) {
-        this.sessionMeta[sessionId].maxIterations = maxIterations;
-      }
-    },
-
-    setSessionModelId(sessionId: string, modelId: string | null) {
-      if (this.sessionMeta[sessionId]) {
-        this.sessionMeta[sessionId].modelId = modelId;
-      }
+    async setSessionModelId(sessionId: string, modelId: string | null) {
+      this.sessions = this.sessions.map(s =>
+        s.id === sessionId ? { ...s, model_id: modelId } : s,
+      );
+      await updateSessionMeta(sessionId, undefined, undefined, modelId).catch(() => {});
     },
 
     async reloadSessionMessages(sessionId: string) {
@@ -899,19 +982,33 @@ export const useDataStudioStore = defineStore('dataStudio', {
 
     // ── Confirmation rules ───────────────────────────────────────────────────
 
+    async loadConfirmationRulesFromDb(sessionId: string): Promise<void> {
+      const rows = await loadConfirmationRules(sessionId);
+      const sessionRules = rows.map(row => ({
+        id: row.id,
+        sessionId: row.session_id,
+        toolName: row.tool_name,
+        action: row.action as 'allow_always' | 'deny_always',
+      }));
+      // Merge: keep rules for other sessions, replace rules for this session
+      this.confirmationRules = [
+        ...this.confirmationRules.filter(r => r.sessionId !== sessionId),
+        ...sessionRules,
+      ];
+    },
+
     findConfirmationRule(sessionId: string, toolName: string): ConfirmationRule | undefined {
       return this.confirmationRules.find(r => r.sessionId === sessionId && r.toolName === toolName);
     },
 
-    addConfirmationRule(rule: ConfirmationRule) {
-      const index = this.confirmationRules.findIndex(
-        r => r.sessionId === rule.sessionId && r.toolName === rule.toolName,
-      );
-      if (index !== -1) {
-        this.confirmationRules = this.confirmationRules.map((r, i) => (i === index ? rule : r));
-      } else {
-        this.confirmationRules = [...this.confirmationRules, rule];
-      }
+    async addConfirmationRule(rule: ConfirmationRule): Promise<void> {
+      await saveConfirmationRule(rule.sessionId, rule.toolName, rule.action);
+      await this.loadConfirmationRulesFromDb(rule.sessionId);
+    },
+
+    async removeConfirmationRule(id: string): Promise<void> {
+      await deleteConfirmationRule(id);
+      this.confirmationRules = this.confirmationRules.filter(r => r.id !== id);
     },
 
     // ── Session CRUD ─────────────────────────────────────────────────────────
@@ -937,23 +1034,23 @@ export const useDataStudioStore = defineStore('dataStudio', {
       const backendSessions = await loadAgentSessions();
       const loaded = await Promise.all(
         backendSessions.map(async (s: BackendAgentSession) => {
-          const raw = this.sessionMeta[s.id] as
-            | (SessionMeta & { connectionId?: number })
-            | undefined;
           const backendMessages = await loadSessionMessages(s.id).catch(
             () => [] as BackendAgentMessage[],
           );
           const messages: Array<AgentMessage> = dedupAdjacentCompactions(
             backendMessages.map(hydrateMessage),
           );
-          const sources: SessionSource[] = raw?.sources ?? [];
+          const sources: SessionSource[] = s.sources ? JSON.parse(s.sources) : [];
           return {
             id: s.id,
+            title: s.title,
             sources,
-            permissionsMode: raw?.permissionsMode ?? ('Ask' as PermissionsMode),
+            permissionsMode: s.permissions_mode as PermissionsMode,
             messages,
             status: s.status as AgentSessionStatus,
-            maxIterations: raw?.maxIterations ?? 10,
+            updated_at: s.updated_at,
+            created_at: s.created_at,
+            model_id: s.model_id ?? null,
           };
         }),
       );
@@ -970,8 +1067,7 @@ export const useDataStudioStore = defineStore('dataStudio', {
     async removeSession(sessionId: string) {
       await deleteAgentSession(sessionId).catch(() => undefined);
       this.sessions = this.sessions.filter(s => s.id !== sessionId);
-      const { [sessionId]: _, ...rest } = this.sessionMeta;
-      this.sessionMeta = rest;
+      // confirmation_rules are CASCADE deleted by the DB — no cleanup needed
       if (this.activeSessionId === sessionId) {
         this.activeSessionId = this.sessions[0]?.id;
       }

--- a/src/views/data-studio/components/session-history-panel.vue
+++ b/src/views/data-studio/components/session-history-panel.vue
@@ -57,19 +57,18 @@ defineEmits<{
 
 const { t } = useI18n();
 const dataStudioStore = useDataStudioStore();
-const { sessions, activeSessionId, sessionMeta } = storeToRefs(dataStudioStore);
+const { sessions, activeSessionId } = storeToRefs(dataStudioStore);
 
 const sortedSessions = computed(() =>
   [...sessions.value].sort((a, b) => {
-    const aTime = sessionMeta.value[a.id]?.updatedAt ?? 0;
-    const bTime = sessionMeta.value[b.id]?.updatedAt ?? 0;
+    const aTime = a.updated_at ?? 0;
+    const bTime = b.updated_at ?? 0;
     return bTime - aTime;
   }),
 );
 
 const sessionLabel = (session: AgentSession): string => {
-  const meta = sessionMeta.value[session.id];
-  if (meta?.title && meta.title !== t('dataStudio.history.newSession')) return meta.title;
+  if (session.title && session.title !== t('dataStudio.history.newSession')) return session.title;
   const sourceLabel = session.sources
     .filter(source => !source.detached)
     .map(source => source.alias)
@@ -79,11 +78,11 @@ const sessionLabel = (session: AgentSession): string => {
   if (firstUser?.content) {
     return firstUser.content.length > 40 ? firstUser.content.slice(0, 40) + '…' : firstUser.content;
   }
-  return meta?.title ?? t('dataStudio.history.sessionFallback');
+  return session.title || t('dataStudio.history.sessionFallback');
 };
 
 const formatTime = (session: AgentSession): string => {
-  const ts = sessionMeta.value[session.id]?.updatedAt ?? 0;
+  const ts = session.updated_at ?? 0;
   if (!ts) return '';
   const d = new Date(ts);
   const now = new Date();

--- a/src/views/data-studio/index.vue
+++ b/src/views/data-studio/index.vue
@@ -414,7 +414,7 @@ const confirmAddSource = async () => {
   if (!addSourceSelectedId.value) return;
   const conn = connections.value.find(c => String(c.id) === addSourceSelectedId.value);
   if (!conn || conn.id === undefined) return;
-  const newSource = dataStudioStore.addDatabaseSourceFromConnection({
+  const newSource = await dataStudioStore.addDatabaseSourceFromConnection({
     connectionId: Number(conn.id),
     name: conn.name,
     databaseType: conn.type as

--- a/src/views/data-studio/index.vue
+++ b/src/views/data-studio/index.vue
@@ -483,7 +483,9 @@ const onModelChange = async (modelId: string) => {
 
 const switchSession = async (sessionId: string) => {
   dataStudioStore.setActiveSession(sessionId);
-  const savedModelId = dataStudioStore.sessionMeta[sessionId]?.modelId;
+  await dataStudioStore.loadConfirmationRulesFromDb(sessionId);
+  const session = dataStudioStore.sessions.find(s => s.id === sessionId);
+  const savedModelId = session?.model_id ?? null;
   if (savedModelId) {
     modelVerified.value = null;
     await appStore.setFeatureModelRoute('dataStudio', {
@@ -511,7 +513,12 @@ const openModifyModal = (index: number) => {
 };
 
 onMounted(async () => {
+  await dataStudioStore.migrateFromLocalStorage();
   await Promise.all([dataStudioStore.loadSessions(), connectionStore.fetchConnections()]);
+  await dataStudioStore.loadAttachedSourcesFromDb();
+  if (dataStudioStore.activeSessionId) {
+    await dataStudioStore.loadConfirmationRulesFromDb(dataStudioStore.activeSessionId);
+  }
   document.addEventListener('click', closeOpenMenus);
   await initContextSettings();
 });


### PR DESCRIPTION
## Summary

Closes #455. Moves session metadata (sources, permissionsMode, modelId), confirmation rules, and attached sources from fragile localStorage (Pinia persist) to durable agent.sqlite.

## Architecture

```
.store.dat (config only)               agent.sqlite (all session data)
├── ChatRuntimeConfig                  ├── agent_sessions
│   ├── maxIterations ← global default │   ├── id, title, status
│   ├── autoCompact                    │   ├── created_at, updated_at
│   └── ...                            │   ├── sources TEXT (JSON)     ← SessionSource[]
│                                      │   ├── permissions_mode TEXT
│   (NOT per-session)                  │   └── model_id TEXT
│                                      │
localStorage (trivial UI state)        ├── agent_messages
├── activeSessionId                    ├── agent_tool_calls
└── sidebarSessionId                   ├── tool_result_store
                                       ├── confirmation_rules
                                       └── attached_sources (pure registry)
```

## Key Design Decisions

- **No `max_iterations` on `agent_sessions`** — always reads from global `ChatRuntimeConfig`. Session-level `maxIterations` was dead code (overwritten by global config at runtime).
- **`attached_sources` is a pure metadata registry** — no permissions columns. Permissions live exclusively in the `SessionSource` snapshot within the `sources` JSON column.
- **One-time migration** reads old localStorage data on first startup and writes to SQLite.

## Changes

### Rust Backend (3 files, +491/-10)
- Versioned schema migration with `PRAGMA user_version`
- 3 new columns on `agent_sessions`: `sources`, `permissions_mode`, `model_id`
- New tables: `confirmation_rules` (UNIQUE+FK CASCADE), `attached_sources` (pure registry)
- 9 new Tauri commands: `update_session_meta`, confirmation_rules CRUD, attached_sources CRUD, `migrate_session_metadata`
- All SQL uses parameterized queries (no string interpolation)

### TypeScript Frontend (7 files, +200/-94)
- `sessionMeta` removed from Pinia state and persist
- `createSession`/ `loadSessions` read metadata directly from Rust
- All 7 mutation actions persist to SQLite via `update_session_meta`
- `attachedSources` and `confirmationRules` backed by SQLite CRUD
- Confirmation rules loaded on startup + session switch (merge strategy preserves cross-session rules)
- `maxIterations` removed — always reads from `ChatRuntimeConfig`

## Verification
- `cargo check` ✅
- `npx tsc --noEmit` ✅
- `npm run lint:check` ✅