### PR TITLE
Add Requesty as an AI provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
       "version": "7.28.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2791,7 +2790,6 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3923,7 +3921,6 @@
     "node_modules/@vueuse/core": {
       "version": "14.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
         "@vueuse/metadata": "14.1.0",
@@ -3957,7 +3954,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5529,7 +5525,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5588,7 +5583,6 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7024,7 +7018,6 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8478,7 +8471,6 @@
     "node_modules/pinia": {
       "version": "3.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -8655,7 +8647,6 @@
       "version": "3.8.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9908,7 +9899,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10154,7 +10144,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10340,7 +10329,6 @@
       "version": "66.6.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@unocss/astro": "66.6.0",
         "@unocss/cli": "66.6.0",
@@ -10679,7 +10667,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10782,7 +10769,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10798,7 +10784,6 @@
     "node_modules/vue": {
       "version": "3.5.27",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",
@@ -10821,6 +10806,7 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -10845,6 +10831,7 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -11229,7 +11216,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/datasources/chatBotApi.ts
+++ b/src/datasources/chatBotApi.ts
@@ -7,6 +7,7 @@ export enum ProviderEnum {
   OPENAI = 'OPENAI',
   DEEP_SEEK = 'DEEP_SEEK',
   OPENROUTER = 'OPENROUTER',
+  REQUESTY = 'REQUESTY',
   OLLAMA = 'OLLAMA',
   LM_STUDIO = 'LM_STUDIO',
 }

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -140,11 +140,17 @@ export const enUS = {
         openrouterAuthTitle: 'Connect OpenRouter',
         openrouterAuthDesc:
           'Use website auth first, or fall back to a standard API key if you prefer manual setup.',
+        requestyAuthTitle: 'Connect Requesty',
+        requestyAuthDesc:
+          'Use website auth first, or fall back to a standard API key if you prefer manual setup.',
         websiteTab: 'Website',
         apiKeyTab: 'API Key',
         websiteTabDescription:
           'Open OpenRouter in your browser, finish setup there, then return and save your provider if you want to keep it shared in DocKit.',
         openRouterConnect: 'Open OpenRouter website',
+        requestyWebsiteTabDescription:
+          'Open Requesty in your browser, finish setup there, then return and save your provider if you want to keep it shared in DocKit.',
+        requestyConnect: 'Open Requesty website',
         useApiKey: 'Use API key instead',
         featureRequest: 'Create feature request',
         contextWindowLabel: 'Context window override (tokens)',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -136,11 +136,16 @@ export const zhCN = {
         proxyNone: '无（直连）',
         openrouterAuthTitle: '连接 OpenRouter',
         openrouterAuthDesc: '优先使用网页授权；如果你更喜欢手动配置，也可以切换为 API Key。',
+        requestyAuthTitle: '连接 Requesty',
+        requestyAuthDesc: '优先使用网页授权；如果你更喜欢手动配置，也可以切换为 API Key。',
         websiteTab: '网页授权',
         apiKeyTab: 'API Key',
         websiteTabDescription:
           '在浏览器中打开 OpenRouter 完成授权或密钥配置，返回后即可将该服务商保存到 DocKit 的共享提供方列表中。',
         openRouterConnect: '打开 OpenRouter 网站',
+        requestyWebsiteTabDescription:
+          '在浏览器中打开 Requesty 完成授权或密钥配置，返回后即可将该服务商保存到 DocKit 的共享提供方列表中。',
+        requestyConnect: '打开 Requesty 网站',
         useApiKey: '改用 API Key',
         featureRequest: '创建功能需求',
         contextWindowLabel: '上下文窗口覆盖（tokens）',

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -28,6 +28,7 @@ export type ProviderKind =
   | 'openai'
   | 'deepseek'
   | 'openrouter'
+  | 'requesty'
   | 'ollama'
   | 'lm-studio'
   | 'custom-openai'
@@ -149,6 +150,15 @@ const PROVIDER_PRESETS: ProviderPreset[] = [
     defaultModels: ['openai/gpt-4.1-mini', 'anthropic/claude-3.7-sonnet', 'google/gemini-2.5-pro'],
   },
   {
+    kind: 'requesty',
+    apiCompatibility: 'openai-compatible',
+    label: 'Requesty',
+    authMode: 'api-key',
+    defaultBaseUrl: 'https://router.requesty.ai/v1',
+    enabled: true,
+    defaultModels: ['openai/gpt-4.1-mini', 'anthropic/claude-3.7-sonnet', 'google/gemini-2.5-pro'],
+  },
+  {
     kind: 'anthropic',
     apiCompatibility: 'anthropic',
     label: 'Anthropic',
@@ -235,6 +245,7 @@ const defaultModelsByKind: Record<ProviderKind, string[]> = {
   openai: ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4o-mini'],
   deepseek: ['deepseek-chat', 'deepseek-reasoner'],
   openrouter: ['openai/gpt-4.1-mini', 'anthropic/claude-3.7-sonnet', 'google/gemini-2.5-pro'],
+  requesty: ['openai/gpt-4.1-mini', 'anthropic/claude-3.7-sonnet', 'google/gemini-2.5-pro'],
   ollama: ['llama3.1', 'qwen2.5-coder', 'mistral'],
   'lm-studio': [],
   'custom-openai': [],
@@ -335,6 +346,8 @@ const normalizeProvider = (provider: ProviderEnum | undefined): ProviderKind => 
       return 'deepseek';
     case ProviderEnum.OPENROUTER:
       return 'openrouter';
+    case ProviderEnum.REQUESTY:
+      return 'requesty';
     case ProviderEnum.OLLAMA:
       return 'ollama';
     default:

--- a/src/views/setting/components/aigc.vue
+++ b/src/views/setting/components/aigc.vue
@@ -530,6 +530,12 @@ const providerPresets: Record<
     baseUrl: 'https://openrouter.ai/api/v1',
     apiCompatibility: 'openai-compatible',
   },
+  requesty: {
+    label: 'Requesty',
+    authMode: 'api-key',
+    baseUrl: 'https://router.requesty.ai/v1',
+    apiCompatibility: 'openai-compatible',
+  },
   anthropic: {
     label: 'Anthropic',
     authMode: 'api-key',


### PR DESCRIPTION
Adds Requesty as a provider, mirroring the existing OpenRouter provider.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `Authorization: Bearer` auth.

Changes:
- `src/views/setting/components/aigc.vue`: a `requesty` entry in the provider config map (`baseUrl: https://router.requesty.ai/v1`, `apiCompatibility: 'openai-compatible'`), mirroring `openrouter`.
- `src/store/appStore.ts`: `'requesty'` in the `ProviderKind` union, a `requesty` preset in `PROVIDER_PRESETS`, an entry in `defaultModelsByKind` (keeps the `Record<ProviderKind, …>` exhaustive), and a `normalizeProvider` case.
- `src/datasources/chatBotApi.ts`: `REQUESTY` in the legacy provider enum (dispatch is generic/OpenAI-compatible, so no request-shape branch is needed).
- `src/lang/enUS.ts` + `src/lang/zhCN.ts`: Requesty UI-flow labels mirroring OpenRouter (zh uses the brand name literally).

`vue-tsc --noEmit` passes clean.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.