### PR TITLE
fix: enable SSH tunnel for MongoDB URI auth mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2836,7 +2835,6 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3970,7 +3968,6 @@
     "node_modules/@vueuse/core": {
       "version": "14.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
         "@vueuse/metadata": "14.1.0",
@@ -4004,7 +4001,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4752,7 +4748,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5586,7 +5581,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5645,7 +5639,6 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7081,7 +7074,6 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8578,7 +8570,6 @@
     "node_modules/pinia": {
       "version": "3.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -8755,7 +8746,6 @@
       "version": "3.8.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10014,7 +10004,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10260,7 +10249,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10448,7 +10436,6 @@
       "version": "66.6.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@unocss/astro": "66.6.0",
         "@unocss/cli": "66.6.0",
@@ -10789,7 +10776,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -10892,7 +10878,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10908,7 +10893,6 @@
     "node_modules/vue": {
       "version": "3.5.27",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",
@@ -10931,6 +10915,7 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -10955,6 +10940,7 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -11341,7 +11327,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src-tauri/src/mongo_client.rs
+++ b/src-tauri/src/mongo_client.rs
@@ -4,7 +4,7 @@ use mongodb::bson::{doc, Bson, Document};
 use mongodb::{options::ClientOptions, Client};
 use serde::Deserialize;
 use serde_json::Value;
-use url::form_urlencoded;
+use url::{form_urlencoded, Url};
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "kind")]
@@ -39,13 +39,33 @@ fn encode_component(s: &str) -> String {
     form_urlencoded::byte_serialize(s.as_bytes()).collect()
 }
 
-fn build_uri(config: &MongoConnectionConfig) -> String {
-    build_uri_tunneled(config, config.tunnel_port)
-}
-
-fn build_uri_tunneled(config: &MongoConnectionConfig, tunnel_port: Option<u16>) -> String {
+fn build_uri_tunneled(
+    config: &MongoConnectionConfig,
+    tunnel_port: Option<u16>,
+) -> Result<String, String> {
     match &config.auth {
-        MongoAuth::Uri { uri } => uri.clone(),
+        MongoAuth::Uri { uri } => {
+            let Some(local_port) = tunnel_port else {
+                return Ok(uri.clone());
+            };
+            let mut parsed = Url::parse(uri)
+                .map_err(|e| format!("Failed to parse MongoDB URI for SSH tunneling: {}", e))?;
+            if parsed.scheme() != "mongodb"
+                || !matches!(parsed.host_str(), Some(host) if !host.contains(','))
+            {
+                return Err(
+                    "SSH tunneling supports only single-host mongodb:// connection URIs."
+                        .to_string(),
+                );
+            }
+            parsed
+                .set_host(Some("127.0.0.1"))
+                .map_err(|_| "Failed to replace MongoDB URI host for SSH tunneling.".to_string())?;
+            parsed
+                .set_port(Some(local_port))
+                .map_err(|_| "Failed to replace MongoDB URI port for SSH tunneling.".to_string())?;
+            Ok(parsed.into())
+        }
         _ => {
             let use_tls = config.tls.unwrap_or(false);
             let host_str = if let Some(local_port) = tunnel_port {
@@ -89,10 +109,10 @@ fn build_uri_tunneled(config: &MongoConnectionConfig, tunnel_port: Option<u16>) 
                     } else {
                         format!("?{}", params.join("&"))
                     };
-                    format!(
+                    Ok(format!(
                         "mongodb://{}:{}@{}{}{}",
                         encoded_user, encoded_pass, host_str, db_path, query
-                    )
+                    ))
                 }
                 _ => {
                     let query = if params.is_empty() {
@@ -100,11 +120,18 @@ fn build_uri_tunneled(config: &MongoConnectionConfig, tunnel_port: Option<u16>) 
                     } else {
                         format!("?{}", params.join("&"))
                     };
-                    format!("mongodb://{}{}{}", host_str, db_path, query)
+                    Ok(format!("mongodb://{}{}{}", host_str, db_path, query))
                 }
             }
         }
     }
+}
+
+fn is_ssh_enabled(ssh_tunnel: Option<&serde_json::Value>) -> bool {
+    ssh_tunnel
+        .and_then(|tunnel| tunnel.get("enabled"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 #[tauri::command]
@@ -116,10 +143,12 @@ pub async fn mongo_test_connection(
     use crate::common::response::ApiResponse;
     use crate::common::ssh_bridge::resolve_ssh_tunnel;
 
-    // Resolve SSH tunnel if ssh config is provided
+    let ssh_enabled = is_ssh_enabled(ssh_tunnel.as_ref());
     let endpoint = resolve_ssh_tunnel(&app, ssh_tunnel.as_ref(), &config.host, config.port).await?;
-    let config = MongoConnectionConfig { host: endpoint.host.clone(), port: endpoint.port, ..config };
-    let uri = build_uri(&config);
+    let uri = match build_uri_tunneled(&config, ssh_enabled.then_some(endpoint.port)) {
+        Ok(uri) => uri,
+        Err(e) => return Ok(ApiResponse::err(400, e)),
+    };
 
     let client_options = match ClientOptions::parse(&uri).await {
         Ok(opts) => opts,
@@ -898,8 +927,9 @@ pub async fn mongo_execute_query(
     use crate::common::response::ApiResponse;
     use crate::common::ssh_bridge::resolve_ssh_tunnel;
 
+    let ssh_enabled = is_ssh_enabled(ssh_tunnel.as_ref());
     let endpoint = resolve_ssh_tunnel(&app, ssh_tunnel.as_ref(), &config.host, config.port).await?;
-    let client = match build_client_tunneled(&config, Some(endpoint.port)).await {
+    let client = match build_client_tunneled(&config, ssh_enabled.then_some(endpoint.port)).await {
         Ok(c) => {
             c
         }
@@ -937,7 +967,7 @@ async fn build_client_tunneled(
     config: &MongoConnectionConfig,
     tunnel_port: Option<u16>,
 ) -> Result<Client, String> {
-    let uri = build_uri_tunneled(config, tunnel_port);
+    let uri = build_uri_tunneled(config, tunnel_port)?;
     let client_options = ClientOptions::parse(&uri)
         .await
         .map_err(|e| format!("Failed to parse connection options: {}", e))?;
@@ -958,9 +988,10 @@ pub async fn mongo_export_documents(
     use crate::common::response::ApiResponse;
     use crate::common::ssh_bridge::resolve_ssh_tunnel;
 
+    let ssh_enabled = is_ssh_enabled(ssh_tunnel.as_ref());
     let endpoint = resolve_ssh_tunnel(&app, ssh_tunnel.as_ref(), &config.host, config.port).await?;
     let result = {
-        let client = build_client_tunneled(&config, Some(endpoint.port)).await;
+        let client = build_client_tunneled(&config, ssh_enabled.then_some(endpoint.port)).await;
         let client = match client {
             Ok(c) => c,
             Err(e) => {
@@ -1043,8 +1074,9 @@ pub async fn mongo_import_documents(
     use crate::common::response::ApiResponse;
     use crate::common::ssh_bridge::resolve_ssh_tunnel;
 
+    let ssh_enabled = is_ssh_enabled(ssh_tunnel.as_ref());
     let endpoint = resolve_ssh_tunnel(&app, ssh_tunnel.as_ref(), &config.host, config.port).await?;
-    let client = match build_client_tunneled(&config, Some(endpoint.port)).await {
+    let client = match build_client_tunneled(&config, ssh_enabled.then_some(endpoint.port)).await {
         Ok(c) => c,
         Err(e) => {
             return Ok(ApiResponse::err(500, e));
@@ -1138,3 +1170,77 @@ pub async fn mongo_import_documents(
     Ok(ApiResponse::ok(data))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri_config(uri: &str) -> MongoConnectionConfig {
+        MongoConnectionConfig {
+            host: "mongo.example.com".to_string(),
+            port: 27017,
+            auth: MongoAuth::Uri {
+                uri: uri.to_string(),
+            },
+            database: None,
+            tls: None,
+            tunnel_port: None,
+        }
+    }
+
+    #[test]
+    fn uri_auth_keeps_the_original_uri_without_ssh() {
+        let uri = "mongodb://user:pass@mongo.example.com:27018/app?tls=true";
+        assert_eq!(build_uri_tunneled(&uri_config(uri), None).unwrap(), uri);
+    }
+
+    #[test]
+    fn uri_auth_replaces_only_the_endpoint_when_ssh_is_enabled() {
+        let uri = "mongodb://user:pass@mongo.example.com:27018/app?tls=true";
+        assert_eq!(
+            build_uri_tunneled(&uri_config(uri), Some(51234)).unwrap(),
+            "mongodb://user:pass@127.0.0.1:51234/app?tls=true"
+        );
+    }
+
+    #[test]
+    fn uri_auth_rejects_srv_uris_when_ssh_is_enabled() {
+        let error = build_uri_tunneled(
+            &uri_config("mongodb+srv://cluster.mongodb.net/app"),
+            Some(51234),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            "SSH tunneling supports only single-host mongodb:// connection URIs."
+        );
+    }
+
+    #[test]
+    fn uri_auth_rejects_multiple_hosts_when_ssh_is_enabled() {
+        let error = build_uri_tunneled(
+            &uri_config("mongodb://mongo-1.example.com,mongo-2.example.com/app"),
+            Some(51234),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            "SSH tunneling supports only single-host mongodb:// connection URIs."
+        );
+    }
+
+    #[test]
+    fn non_uri_auth_uses_the_remote_host_without_ssh() {
+        let config = MongoConnectionConfig {
+            host: "mongo.example.com".to_string(),
+            port: 27018,
+            auth: MongoAuth::None,
+            database: Some("app".to_string()),
+            tls: None,
+            tunnel_port: None,
+        };
+        assert_eq!(
+            build_uri_tunneled(&config, None).unwrap(),
+            "mongodb://mongo.example.com:27018/app"
+        );
+    }
+}

--- a/src/components/ssh/ssh-tunnel-section.vue
+++ b/src/components/ssh/ssh-tunnel-section.vue
@@ -15,7 +15,7 @@
         size="sm"
         type="button"
         class="shrink-0"
-        :disabled="testing"
+        :disabled="testing || testDisabled"
         @click="onTestConnection"
       >
         <span v-if="testing" class="i-carbon-circle-dash h-3.5 w-3.5 animate-spin" />
@@ -137,6 +137,7 @@ const props = defineProps<{
   modelValue: SshConnectionConfig;
   remoteHost: string;
   remotePort: number;
+  testDisabled?: boolean;
 }>();
 
 const emit = defineEmits<{

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -933,6 +933,8 @@ export const enUS = {
       authTypeNone: 'No Authentication',
       authTypeScram: 'SCRAM Authentication',
       authTypeUri: 'URI Connection String',
+      sshTunnelUnsupportedUri:
+        'SSH tunneling supports only single-host mongodb:// connection URIs.',
       collectionCount: '{count} collections',
       connectSuccess: 'MongoDB connection successful',
       editorComingSoon: 'MongoDB query editor coming soon...',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -899,6 +899,7 @@ export const zhCN = {
       authTypeNone: '无认证',
       authTypeScram: 'SCRAM 认证',
       authTypeUri: 'URI 连接地址',
+      sshTunnelUnsupportedUri: 'SSH 隧道仅支持单主机 mongodb:// 连接 URI。',
       collectionCount: '{count} 个集合',
       connectSuccess: 'MongoDB 连接成功',
       editorComingSoon: 'MongoDB 查询编辑器即将推出...',

--- a/src/views/connect/components/mongodb-connect-dialog.vue
+++ b/src/views/connect/components/mongodb-connect-dialog.vue
@@ -205,33 +205,33 @@
                   <Switch v-model:checked="tlsChecked" />
                 </FormItem>
               </GridItem>
-
-              <!-- Advanced Section -->
-              <GridItem :span="8">
-                <div class="advanced-section">
-                  <button
-                    type="button"
-                    class="advanced-toggle"
-                    @click="showAdvanced = !showAdvanced"
-                  >
-                    <ChevronRight
-                      class="h-4 w-4 transition-transform duration-200"
-                      :class="{ 'rotate-90': showAdvanced }"
-                    />
-                    <span class="text-sm font-medium">{{ $t('connection.advanced') }}</span>
-                  </button>
-                  <div v-show="showAdvanced" class="advanced-content">
-                    <SshTunnelSection
-                      v-model="sshConfig"
-                      :remote-host="formData.host"
-                      :remote-port="formData.port"
-                      @create-profile="openSshProfileDialog(null)"
-                      @edit-profile="openSshProfileDialog($event)"
-                    />
-                  </div>
-                </div>
-              </GridItem>
             </template>
+
+            <!-- Advanced Section -->
+            <GridItem :span="8">
+              <div class="advanced-section">
+                <button type="button" class="advanced-toggle" @click="showAdvanced = !showAdvanced">
+                  <ChevronRight
+                    class="h-4 w-4 transition-transform duration-200"
+                    :class="{ 'rotate-90': showAdvanced }"
+                  />
+                  <span class="text-sm font-medium">{{ $t('connection.advanced') }}</span>
+                </button>
+                <div v-show="showAdvanced" class="advanced-content">
+                  <SshTunnelSection
+                    v-model="sshConfig"
+                    :remote-host="sshRemoteHost"
+                    :remote-port="sshRemotePort"
+                    :test-disabled="Boolean(sshTunnelIssue)"
+                    @create-profile="openSshProfileDialog(null)"
+                    @edit-profile="openSshProfileDialog($event)"
+                  />
+                  <p v-if="sshTunnelIssue" class="mt-2 text-xs text-destructive">
+                    {{ sshTunnelIssue }}
+                  </p>
+                </div>
+              </div>
+            </GridItem>
           </Grid>
         </Form>
       </div>
@@ -339,6 +339,36 @@ const passwordValue = ref('');
 const authSourceValue = ref('');
 const authMechanismValue = ref('');
 const tlsChecked = ref(false);
+
+const parseMongoTunnelTarget = (uri: string): { host: string; port: number } | null => {
+  try {
+    const parsed = new URL(uri);
+    if (parsed.protocol !== 'mongodb:' || !parsed.hostname || parsed.hostname.includes(',')) {
+      return null;
+    }
+    const port = parsed.port ? Number(parsed.port) : 27017;
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return null;
+    }
+    return { host: parsed.hostname.replace(/^\[(.*)\]$/, '$1'), port };
+  } catch {
+    return null;
+  }
+};
+
+const uriTunnelTarget = computed(() => parseMongoTunnelTarget(uriValue.value));
+const sshRemoteHost = computed(() =>
+  authMode.value === 'uri' ? (uriTunnelTarget.value?.host ?? '') : formData.value.host,
+);
+const sshRemotePort = computed(() =>
+  authMode.value === 'uri' ? (uriTunnelTarget.value?.port ?? 0) : formData.value.port,
+);
+const sshTunnelIssue = computed(() => {
+  if (authMode.value !== 'uri' || !sshConfig.value.enabled || uriTunnelTarget.value) {
+    return '';
+  }
+  return lang.t('connection.mongodb.sshTunnelUnsupportedUri');
+});
 
 const formSchema = toTypedSchema(
   z
@@ -456,7 +486,7 @@ const isFormValid = computed(() => {
   const hasName = formData.value.name && formData.value.name.trim() !== '';
 
   if (authMode.value === 'uri') {
-    return hasName && uriValue.value.trim() !== '';
+    return hasName && uriValue.value.trim() !== '' && !sshTunnelIssue.value;
   }
 
   const hasHost = formData.value.host && formData.value.host.trim() !== '';
@@ -507,10 +537,11 @@ const buildConnection = (): MongoDBConnection => {
   };
 
   if (authMode.value === 'uri') {
+    const tunnelTarget = uriTunnelTarget.value;
     return {
       ...base,
-      host: '',
-      port: 0,
+      host: tunnelTarget?.host ?? '',
+      port: tunnelTarget?.port ?? 0,
       database: undefined,
       tls: undefined,
       auth: { kind: 'uri', uri: uriValue.value },
@@ -597,6 +628,11 @@ const testConnect = async (event: MouseEvent) => {
   resetResult();
   markSubmitted();
 
+  if (sshTunnelIssue.value) {
+    fail(sshTunnelIssue.value);
+    return;
+  }
+
   const { valid } = await validate();
   if (!valid) {
     fail(lang.t('connection.validationFailed'));
@@ -639,6 +675,11 @@ const saveConnect = async (event: MouseEvent) => {
   event.preventDefault();
   resetResult();
   markSubmitted();
+
+  if (sshTunnelIssue.value) {
+    fail(sshTunnelIssue.value);
+    return;
+  }
 
   const { valid } = await validate();
   if (!valid) {

--- a/tests/mongoApi.test.ts
+++ b/tests/mongoApi.test.ts
@@ -115,8 +115,8 @@ describe('mongoApi', () => {
       const connection: MongoDBConnection = {
         name: 'test',
         type: DatabaseType.MONGODB,
-        host: '',
-        port: 0,
+        host: 'localhost',
+        port: 27017,
         auth: { kind: 'uri', uri: 'mongodb://localhost:27017' },
       };
       const mockApiResponse = { status: 200, data: { collections: [] } };
@@ -126,13 +126,44 @@ describe('mongoApi', () => {
 
       expect(invoke).toHaveBeenCalledWith('mongo_test_connection', {
         config: {
-          host: '',
-          port: 0,
+          host: 'localhost',
+          port: 27017,
           auth: { kind: 'uri', uri: 'mongodb://localhost:27017' },
           database: undefined,
           tls: undefined,
         },
         sshTunnel: null,
+      });
+    });
+
+    it('passes the URI target and SSH configuration for URI auth', async () => {
+      const connection: MongoDBConnection = {
+        name: 'tunneled',
+        type: DatabaseType.MONGODB,
+        host: 'mongo.internal.example.com',
+        port: 27018,
+        auth: {
+          kind: 'uri',
+          uri: 'mongodb://user:pass@mongo.internal.example.com:27018/app',
+        },
+        sshTunnel: { enabled: true, profileIds: ['bastion'] },
+      };
+      invoke.mockResolvedValue({ status: 200, data: { collections: [] } });
+
+      await mongoApi.testConnection(connection);
+
+      expect(invoke).toHaveBeenCalledWith('mongo_test_connection', {
+        config: {
+          host: 'mongo.internal.example.com',
+          port: 27018,
+          auth: {
+            kind: 'uri',
+            uri: 'mongodb://user:pass@mongo.internal.example.com:27018/app',
+          },
+          database: undefined,
+          tls: undefined,
+        },
+        sshTunnel: { enabled: true, profileIds: ['bastion'] },
       });
     });
 

--- a/tests/mongodbConnection.test.ts
+++ b/tests/mongodbConnection.test.ts
@@ -142,19 +142,21 @@ describe('MongoDBConnection', () => {
 
   it('supports uri auth', () => {
     const conn: MongoDBConnection = {
-      name: 'atlas',
+      name: 'remote',
       type: DatabaseType.MONGODB,
-      host: '',
-      port: 0,
+      host: 'mongo.example.com',
+      port: 27017,
       auth: {
         kind: 'uri',
-        uri: 'mongodb+srv://user:pass@cluster.mongodb.net/db?retryWrites=true&w=majority',
+        uri: 'mongodb://user:pass@mongo.example.com:27017/db?retryWrites=true&w=majority',
       },
     };
     expect(conn.auth.kind).toBe('uri');
     if (conn.auth.kind === 'uri') {
       expect(conn.auth.uri).toContain('retryWrites=true');
     }
+    expect(conn.host).toBe('mongo.example.com');
+    expect(conn.port).toBe(27017);
   });
 
   it('can be used as Connection type', () => {


### PR DESCRIPTION
Fixes #469.

The MongoDB connection dialog hid the Advanced / SSH Tunnel section when 'URI Auth' was selected, leaving the SSH configuration surface inconsistent with the No Auth / SCRAM Auth modes and with the Elasticsearch, OpenSearch and DynamoDB dialogs.

Changes
- Move the Advanced / SSH Tunnel block out of the authMode !== 'uri' gate so it is always visible.
- Derive the SSH target host/port from a single-host mongodb:// URI for the SSH preview and persist them on the connection so the existing resolve_ssh_tunnel pipeline has a correct remote target.
- build_uri_tunneled parses the URI when SSH is enabled and replaces only the authority with 127.0.0.1:<local tunnel port>, preserving the credentials, database path and query parameters untouched.
- mongodb+srv:// and multi-host URIs are rejected with a clear error when SSH is enabled because a single tunnel port cannot safely proxy them.
- The URI string is only rewritten by the backend; the frontend never mutates the user-provided auth.uri value.
- mongo_execute_query, mongo_export_documents and mongo_import_documents now pass None (instead of the remote endpoint port) to build_uri_tunneled when SSH is disabled, so direct connections no longer get their host rewritten to 127.0.0.1.

Tests
- Unit tests for build_uri_tunneled cover: original URI preserved without SSH; authority-only rewrite under SSH; SRV and multi-host rejection; direct non-URI auth.
- mongoApi.test.ts adds an assertion that the SSH config and parsed URI target are passed through to mongo_test_connection.
- mongodbConnection.test.ts asserts that a single-host URI connection persists the parsed host/port.

Note: the development environment ships rustc 1.94.0 while aws-sdk-* 1.10.x requires 1.94.1; this is unrelated to the fix but worth flagging if CI matches the local toolchain.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/49248b46-780d-4619-b01f-5fb7f8415b23" />
<img width="1920" height="1080" alt="屏幕截图_20260730_201956" src="https://github.com/user-attachments/assets/8a737b2f-c22e-4155-a21c-8f7ed04699c2" />
