### PR TITLE
feat: console index/collection deselect + fix test connection with default index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,9 @@ reddit-post-dockit.md
 .omo/
 .impeccable.md
 .codegraph/
+
+# Local agent tooling (opencode/playwright MCP)
+.github/agents/
+.github/hooks/
+.github/skills/
+.playwright-mcp/

--- a/src/components/tool-bar.vue
+++ b/src/components/tool-bar.vue
@@ -66,6 +66,7 @@
       :placeholder="$t('connection.selectIndex')"
       variant="ghost"
       :search-threshold="0"
+      clearable
       class="index-select"
       @update:model-value="value => handleUpdate(value, 'INDEX')"
       @open="isOpen => handleOpen(isOpen, 'INDEX')"
@@ -378,8 +379,14 @@ const message = useMessageService();
 const lang = useLang();
 
 const connectionStore = useConnectionStore();
-const { fetchConnections, fetchIndices, fetchTables, fetchCollections, selectIndex } =
-  connectionStore;
+const {
+  fetchConnections,
+  fetchIndices,
+  fetchTables,
+  fetchCollections,
+  selectIndex,
+  clearActiveIndex,
+} = connectionStore;
 const { connections } = storeToRefs(connectionStore);
 
 const tabStore = useTabStore();
@@ -496,18 +503,31 @@ const connectionOptions = computed(() =>
     .sort((a, b) => a.label.localeCompare(b.label)),
 );
 
-const indexOptions = computed(
-  () =>
-    activeSearchIndexOption.value
-      ?.filter(index => (includeSystemIndicesRef.value ? true : !index.value.startsWith('.')))
-      ?.sort((a, b) => {
-        const aIsSystem = a.value.startsWith('.');
-        const bIsSystem = b.value.startsWith('.');
-        if (aIsSystem && !bIsSystem) return 1;
-        if (!aIsSystem && bIsSystem) return -1;
-        return a.label.localeCompare(b.label);
-      }) ?? [],
-);
+const indexOptions = computed(() => {
+  const conn = activePanel?.value?.connection;
+  const selected = isSearchConnection(conn)
+    ? (conn as SearchConnection).activeIndex?.index
+    : undefined;
+  const base = activeSearchIndexOption.value ?? [];
+  // Always surface the selected index, even when the index listing is
+  // unavailable (e.g. the credentials lack permission for /_cat/indices)
+  const merged =
+    selected && !base.some(opt => opt.value === selected)
+      ? [{ label: selected, value: selected }, ...base]
+      : base;
+  return merged
+    .filter(
+      index =>
+        includeSystemIndicesRef.value || index.value === selected || !index.value.startsWith('.'),
+    )
+    .sort((a, b) => {
+      const aIsSystem = a.value.startsWith('.');
+      const bIsSystem = b.value.startsWith('.');
+      if (aIsSystem && !bIsSystem) return 1;
+      if (!aIsSystem && bIsSystem) return -1;
+      return a.label.localeCompare(b.label);
+    });
+});
 
 const tableOptions = computed(() => {
   const conn = (
@@ -864,7 +884,15 @@ const handleUpdate = async (
       });
       return;
     }
-    selectIndex(selectedConnection, value);
+    // Deselect when the clear button emits '' or the selected index is re-clicked
+    if (
+      isSearchConnection(selectedConnection) &&
+      (value === '' || value === indexSelectValue.value)
+    ) {
+      await clearActiveIndex(selectedConnection);
+    } else {
+      await selectIndex(selectedConnection, value);
+    }
     syncEsConnectUrl();
   }
 };

--- a/src/components/ui/combobox/SearchableSelect.vue
+++ b/src/components/ui/combobox/SearchableSelect.vue
@@ -19,6 +19,7 @@ const props = withDefaults(
     createText?: string;
     searchThreshold?: number;
     variant?: 'outline' | 'ghost';
+    clearable?: boolean;
     class?: string;
   }>(),
   {
@@ -31,6 +32,7 @@ const props = withDefaults(
     createText: 'Create',
     searchThreshold: 10,
     variant: 'outline',
+    clearable: false,
     class: undefined,
   },
 );
@@ -235,6 +237,11 @@ watch(searchQuery, () => {
             <slot name="option" :option="option">
               {{ option.label }}
             </slot>
+            <span
+              v-if="clearable && option.value === modelValue"
+              class="i-carbon-close h-3.5 w-3.5 ml-auto shrink-0 opacity-60"
+              aria-hidden="true"
+            />
           </div>
 
           <div

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -783,10 +783,9 @@ export const useConnectionStore = defineStore('connectionStore', {
         con.type === DatabaseType.EASYSEARCH
       ) {
         const client = loadHttpClient(con);
-        const clusterInfo = await client.get<ElasticsearchClusterInfo>(
-          con.activeIndex?.index,
-          'format=json',
-        );
+        // Cluster info is served at the root endpoint — an index path returns
+        // index metadata without a `version` field and breaks the parsing below
+        const clusterInfo = await client.get<ElasticsearchClusterInfo>('/', 'format=json');
         const detectedAsOpenSearch =
           clusterInfo.version.distribution === 'opensearch' ||
           (clusterInfo.tagline ?? '').toLowerCase().includes('opensearch');
@@ -961,6 +960,23 @@ export const useConnectionStore = defineStore('connectionStore', {
       // selectIndex mutates connectionStore.connections by ID, but the panel
       // may hold a separate reference (e.g. from establishPanel). Without this
       // sync, the toolbar's index selector and docs browser see no activeIndex.
+      if (tabStore.activePanel?.connection?.id === connection.id) {
+        tabStore.activePanel.connection = connection;
+      }
+    },
+    async clearActiveIndex(con: Connection) {
+      const connection = this.connections.find(({ id }) => id === con.id) as SearchConnection;
+      connection.activeIndex = undefined;
+      const tabStore = useTabStore();
+      configureDynamicOptions({
+        activeIndex: undefined,
+        indices: connection.indices?.map(i => i.index) ?? [],
+        includeSystemIndices: tabStore.activePanel?.includeSystemIndices ?? false,
+        fields: undefined,
+      });
+
+      // Sync the cleared connection into the active panel so the toolbar's
+      // index selector and docs browser observe the deselected state.
       if (tabStore.activePanel?.connection?.id === connection.id) {
         tabStore.activePanel.connection = connection;
       }

--- a/src/views/connect/index.vue
+++ b/src/views/connect/index.vue
@@ -128,7 +128,7 @@ const applyConnectQueryParams = async () => {
   const conn = activePanel.value.connection;
   if (!conn || !isSearchConnection(conn)) return;
 
-  if (index) {
+  if (index && index !== conn.activeIndex?.index) {
     await selectIndex(conn, index);
   }
   const editorType = editorTypeFromConnectView(view);


### PR DESCRIPTION
## Summary

Fixes #476 — adds the ability to **deselect** the collection/index in the Console's selector, plus two related fixes found while implementing it.

## Changes

### 1. Console index deselect (issue #476)
- `SearchableSelect.vue`: new opt-in `clearable` prop — when the current option is selected, an × indicator renders at the right of the row in the dropdown list (other selects unaffected; default `false`)
- `tool-bar.vue`: `clearable` enabled on the ES index selector; clicking the already-selected index row (or the ×) toggles it off → selector returns to "No collection/index selected" state
- `connectionStore.ts`: new `clearActiveIndex(con)` action — sets `activeIndex = undefined`, resets Monaco completion options, syncs the active panel

### 2. Selected index always visible in the dropdown
- `tool-bar.vue` `indexOptions`: the selected index is unioned into the option list and exempt from the system-index filter, so it stays visible even when the credentials lack permission for `/_cat/indices` (the existing error toast still notifies)

### 3. Fix: "Connection failed (status: undefined)" when test/save with a default index
- `connectionStore.ts` `freshConnection`: cluster info is now fetched from the root endpoint (`/`) instead of `/{index}` — an index path returns index metadata without a `version` field, crashing the parser (`TypeError` → "status: undefined"). Affected the dialog test, `establishPanel`, connect-from-list, and import/export refresh whenever a connection had an `activeIndex`

### 4. Fix: selection race (wrong index selected / selector flickering)
- `tool-bar.vue` `handleUpdate`: `selectIndex` is now awaited before `syncEsConnectUrl()` — previously the URL got a stale index, the route-query watcher re-selected it, and two competing `selectIndex` calls raced (last-finisher-wins → wrong selection, repeated re-renders → shaking)
- `connect/index.vue` `applyConnectQueryParams`: idempotence guard — skips re-selection when the URL index already matches the current `activeIndex`

## Verification
- `npx tsc --noEmit` clean
- `eslint` clean on all changed files
- Deselect flow: open dropdown → click selected row → placeholder state, `GET /_search` runs cluster-wide, explicit-index queries unaffected, index remains in list for re-select