### PR TITLE
fix: executing query should not auto-fill the index selector

### DIFF
--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -1026,24 +1026,6 @@ export const useConnectionStore = defineStore('connectionStore', {
         throw new Error('Operation only supported for Elasticsearch/OpenSearch connections');
       }
       const client = loadHttpClient(connection);
-      // refresh the index mapping
-      try {
-        if (index && index !== connection.activeIndex?.index) {
-          const newIndex = (connection.indices as ElasticSearchIndex[]).find(
-            ({ index: indexName }) => indexName === index,
-          ) as ElasticSearchIndex;
-
-          if (newIndex) {
-            if (!newIndex.mapping) {
-              newIndex.mapping = await client.get(`/${index}/_mapping`, 'format=json');
-            }
-            connection.activeIndex = newIndex;
-          }
-        }
-      } catch (_err) {
-        // Silently ignore mapping fetch errors
-      }
-
       const reqPath = buildPath(index, path, connection);
 
       const dispatch: { [method: string]: () => Promise<unknown> } = {

--- a/tests/connectionStore.test.ts
+++ b/tests/connectionStore.test.ts
@@ -1799,6 +1799,31 @@ describe('connectionStore - searchQDSL', () => {
     await store.searchQDSL(conn, { method: 'GET', path: '_search', qdsl: '{"query":{}}' });
     expect(mockPost).toHaveBeenCalled();
   });
+
+  it('does not change activeIndex when querying a different index', async () => {
+    const { loadHttpClient } = require('../src/datasources');
+    const mockGet = jest.fn().mockResolvedValue({ hits: { total: 0 } });
+    loadHttpClient.mockReturnValue({ get: mockGet, post: jest.fn() });
+
+    const { useConnectionStore } = require('../src/store/connectionStore');
+    const store = useConnectionStore();
+
+    const conn = {
+      id: 6,
+      type: 'ELASTICSEARCH',
+      name: 'es-test',
+      host: 'http://localhost',
+      port: 9200,
+      indices: [{ index: 'my-index', uuid: 'u1', health: 'green', status: 'open' }],
+      activeIndex: undefined,
+    } as unknown as Connection;
+    store.connections = [conn];
+
+    await store.searchQDSL(conn, { method: 'GET', path: 'my-index' });
+
+    const updatedConn = store.connections[0] as ElasticsearchConnection;
+    expect(updatedConn.activeIndex).toBeUndefined();
+  });
 });
 
 describe('connectionStore - queryToCurl', () => {


### PR DESCRIPTION
Issues #484

## Problem

Executing an index-based query in the Console (e.g. `GET /my-index`) automatically filled the "selected index" field in the toolbar, replacing whatever index the user had manually selected. This is error-prone: the next query (especially index-less ones like `GET /_search`) silently routes to the query's index instead of the user's selection.

## Root cause

`searchQDSL` in `src/store/connectionStore.ts` contained a "refresh the index mapping" block that, whenever the executed query's parsed index differed from `connection.activeIndex`, **replaced** `connection.activeIndex` with the queried index. The toolbar's index selector binds directly to `activeIndex`, so it auto-filled.

The block's mapping-fetch side effect was dead weight: nothing reads a non-active index's cached mapping (`selectIndex` refetches mapping on selection), so the block's only observable behavior was the bug.

## Change

- **`src/store/connectionStore.ts`**: removed the activeIndex mutation block from `searchQDSL`. Query dispatch (`buildPath` + HTTP method routing) is unchanged.
- **`tests/connectionStore.test.ts`**: regression test asserting `searchQDSL` no longer changes `activeIndex` when querying a different index.

## Behavior after fix

- Toolbar index selector only changes via manual selection (`selectIndex`/`clearActiveIndex`) — as expected.
- Queries with an explicit index still hit that index (`buildPath` gives explicit index priority).
- Index-less queries (`GET /_search`) still route to the **manually selected** index via `buildPath` fallback — unchanged.
- Docs browser and agent context follow the user-selected index instead of the last-executed query's index.

## Verification

- `npx tsc --noEmit` — clean
- Full test suite — 35 suites, 1548 tests pass
- ESLint clean on changed files