### PR TITLE
fix(chat): restore Data Studio auto-scroll when answer arrives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,18 +153,23 @@ The `ChatPanel` component (`src/components/chat-panel.vue`) implements a specifi
 | Scenario | Expected Behavior | Implementation |
 |---|---|---|
 | **Panel opens** | Scroll to bottom immediately | `onMounted`: `stickToBottom = true` + double `rAF` after `nextTick` → `scrollToLastMessage()` (Virtualizer `scrollToIndex` with `align: 'end'`) + 300ms `setTimeout` retry (catches Virtualizer layout settling) |
-| **New message arrives** | Auto-scroll if user is near bottom | `watch(messages.length)` → `stickToBottom` guard → `nextTick` → rAF-based `scrollToBottomForce()` (DOM scroll) |
-| **Content streaming** | Auto-scroll if user is near bottom | `watch(last message content)` → `stickToBottom` guard → rAF-batched `scrollToBottomBatched()` (DOM scroll) |
-| **User scrolls up** | Freeze auto-scroll — stay where they are | `handleViewportScroll` listener sets `stickToBottom = false` when `scrollHeight - (scrollTop + clientHeight) > 32px` |
-| **User scrolls back to bottom** | Resume auto-scrolling | Same listener sets `stickToBottom = true` when distance ≤ 32px |
+| **New message arrives** | Auto-scroll if user is near bottom | `watch(messages.length)` → `shouldRestickOnLengthChange(n, old)` re-sticks ONLY on append (`n > old`) → rAF-based `scrollToBottomForce()` (DOM scroll). Length decreases (compaction trim, orphaned-streaming-message removal) do NOT re-stick |
+| **Content streaming** | Auto-scroll if user is near bottom | `watch(computeStreamingSignature(last message))` → `stickToBottom` guard → rAF-batched `scrollToBottomBatched()` (DOM scroll). Signature covers content len, thinking len, message status, and per-tool-call state (status, result len, requiresConfirmation) so tool results and confirmation cards also scroll |
+| **User scrolls up** | Freeze auto-scroll — stay where they are | `handleViewportScroll` → `decideStickOnScroll()` sets `stickToBottom = false` ONLY on genuine upward scroll (`scrollTop < lastScrollTop - 2` AND not near bottom). virtua programmatic scroll corrections (item-add pinning, 160px-estimate→measured adjustments) produce stationary/downward/micro-upward movement → `'keep'`, so they never falsely release the stick |
+| **User scrolls back to bottom** | Resume auto-scrolling | `decideStickOnScroll()` returns `'stick'` when distance ≤ 32px (`isNearBottom`), re-sticking regardless of prior state |
 | **User sends a message** | Force scroll to bottom, resume auto-scrolling | `handleSend` calls `forceScrollToBottom()` before emitting |
 | **User clicks continue** | Force scroll to bottom, resume auto-scrolling | `handleContinue` calls `forceScrollToBottom()` before emitting |
+| **Message status → done** | Final scroll to bottom + settle after virtua post-measure | `watch(last message status)` → `isStatusDoneTransition(old, new)` && `stickToBottom` → `scrollToLastMessage()` (virtua API) + 300ms delayed re-scroll (`statusDoneTimer`, cleared in `onBeforeUnmount`) |
+| **Session switch** | Force scroll to bottom on session change | `watch(() => props.sessionId)` → `forceScrollToBottom()`. ChatPanel persists across session switches (no `:key`/`v-if` in either parent), so `onMounted` does not re-run — this watcher is required |
 
 **Key variables in the component:**
 - `stickToBottom` (`Ref<boolean>`) — controls whether auto-scroll is active
-- `STICKY_THRESHOLD_PX = 32` — how close to bottom counts as "at bottom"
+- `lastScrollTop` (`number`) — previous viewport `scrollTop`, used by `decideStickOnScroll` to detect genuine upward scroll
 - `scrollRafId` — rAF batching guard, prevents redundant scroll calls within one frame
+- `statusDoneTimer` (`ReturnType<typeof setTimeout>`) — 300ms delayed re-scroll after `status → 'done'`, cleared in `onBeforeUnmount`
 - `virtualizerRef` — ref to virtua's Virtualizer component, exposes `scrollToIndex(index)` for reliable scroll-to-last-item (used in `scrollToLastMessage` and `forceScrollToBottom`)
+
+**Scroll decision logic** lives in `src/common/scrollStickiness.ts` (pure functions: `isNearBottom`, `decideStickOnScroll`, `shouldRestickOnLengthChange`, `computeStreamingSignature`, `isStatusDoneTransition`; constants `STICKY_THRESHOLD_PX = 32`, `SCROLL_UP_THRESHOLD_PX = 2`), unit-tested in `tests/common/scrollStickiness.test.ts`. The component contains only thin DOM/rAF/Virtualizer wiring. A browser harness at `tests/manual/scroll-harness.html` (served via `npx vite`) exercises the same module against a real scrollable DOM for manual QA.
 
 **When modifying this behavior:**
 - Never remove the scroll event listener (`'scroll'` on viewport element) — it's the only mechanism that detects user scroll-up
@@ -172,6 +177,7 @@ The `ChatPanel` component (`src/components/chat-panel.vue`) implements a specifi
 - Always call `forceScrollToBottom()` before `emit('send', ...)` in send/continue handlers — this ensures the user's action overrides any scroll-up state
 - `forceScrollToBottom()` and `onMounted` use `scrollToLastMessage()` (Virtualizer `scrollToIndex` API) for scroll-to-bottom — do NOT revert to DOM `scrollTop = scrollHeight` for mount/force-scroll. The Virtualizer computes `scrollHeight` asynchronously and DOM scroll is unreliable before item sizes are measured.
 - Streaming scrolls (`scrollToBottomForce`, `scrollToBottomBatched`) use DOM `scrollTop = scrollHeight` — this works during streaming because virtua has already rendered the items and updates `scrollHeight` incrementally
+- Keep the pure decision functions in `src/common/scrollStickiness.ts` — do not re-inline threshold/decision logic into the component (it would lose unit-test coverage)
 
 ### Known Failure Modes (from real bugs)
 
@@ -184,3 +190,4 @@ The `ChatPanel` component (`src/components/chat-panel.vue`) implements a specifi
 | **Quick UI additions when infrastructure exists** | Before adding a new indicator/label/component, search for existing infrastructure: check `agent-message-bubble.vue`, `context-indicator.vue`, `useChatAgent.ts` phase setters. The "Preparing..." indicator already exists — just needs scroll. |
 | **Proxy ignored in agent loop** | `loop_runner.rs` and `compact.rs` read `proxyMode` from settings. When touching proxy code, verify both paths AND all 10 `create_http_client` call sites. |
 | **ChatPanel scroll broken by refactor** | When modifying `chat-panel.vue`, always preserve the scroll contract table above. Common mistakes: removing the scroll event listener, removing `stickToBottom` guard, or removing `forceScrollToBottom()` before `emit('send')`. |
+| **Auto-scroll stops after virtua layout churn** | `handleViewportScroll` used to flip `stickToBottom = false` on ANY scroll event, including virtua's own programmatic corrections (item-add pinning, 160px-estimate→measured adjustments) — leaving the viewport >32px from the bottom right after `send` → all subsequent auto-scrolls suppressed for the run. Fixed by `decideStickOnScroll`, which only releases on genuine upward scroll (`scrollTop < lastScrollTop - 2` && not near bottom); virtua churn returns `'keep'`. Keep using the pure function — never revert to unconditional `stickToBottom = isNearBottom(el)` |

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -9,6 +9,7 @@ export * from './requestUtil';
 export * from './jsonify.ts';
 export * from './constants';
 export * from './retry';
+export * from './scrollStickiness';
 export * from './asyncUtils';
 export * from './featureFlags';
 export * from './connectQuery';

--- a/src/common/scrollStickiness.ts
+++ b/src/common/scrollStickiness.ts
@@ -1,0 +1,66 @@
+// Pure scroll-decision logic for the chat panel.
+// Extracted to a testable module (no DOM access) so the sticky-to-bottom
+// contract can be unit-tested without mounting the Vue component.
+
+export const STICKY_THRESHOLD_PX = 32;
+export const SCROLL_UP_THRESHOLD_PX = 2;
+
+export type ScrollStickDecision = 'stick' | 'release' | 'keep';
+
+export type ScrollableMessage = {
+  content?: string;
+  thinking?: string;
+  status?: string;
+  toolCalls?: Array<{
+    status: string;
+    result?: string;
+    requiresConfirmation: boolean;
+  }>;
+};
+
+export const isNearBottom = (
+  scrollHeight: number,
+  scrollTop: number,
+  clientHeight: number,
+  threshold: number = STICKY_THRESHOLD_PX,
+): boolean => scrollHeight - (scrollTop + clientHeight) <= threshold;
+
+// Decides the next sticky state from a scroll event.
+// - 'stick'   when the viewport is near the bottom (resume auto-scroll)
+// - 'release' only on genuine upward scroll while NOT near the bottom.
+//             virtua's programmatic corrections (item-add pinning, estimate→
+//             measured size adjustments) produce stationary, downward, or
+//             micro-upward movement — those return 'keep' so stickToBottom
+//             is never falsely released by library-internal scrolling.
+// - 'keep'    otherwise — leave the current state unchanged.
+export const decideStickOnScroll = (
+  currentScrollTop: number,
+  lastScrollTop: number,
+  nearBottom: boolean,
+  scrollUpThreshold: number = SCROLL_UP_THRESHOLD_PX,
+): ScrollStickDecision => {
+  if (nearBottom) return 'stick';
+  if (currentScrollTop < lastScrollTop - scrollUpThreshold) return 'release';
+  return 'keep';
+};
+
+// Re-stick only when messages are APPENDED (n > old). Decreases (compaction
+// trim, orphaned-streaming-message removal) must not yank the viewport.
+export const shouldRestickOnLengthChange = (newLen: number, oldLen: number): boolean =>
+  newLen > oldLen;
+
+// Watch-key signature for the last message. Covers every source of visual
+// growth: content/thinking length, status (streaming → done = answer ready),
+// and per-tool-call state (status, result length, confirmation card).
+export const computeStreamingSignature = (message: ScrollableMessage | undefined): string => {
+  if (!message) return '';
+  const toolCallsSig = (message.toolCalls ?? [])
+    .map(tc => `${tc.status}:${tc.result?.length ?? 0}:${tc.requiresConfirmation ? 1 : 0}`)
+    .join(',');
+  return `${message.content?.length ?? 0}:${message.thinking?.length ?? 0}:${message.status ?? ''}:${toolCallsSig}`;
+};
+
+export const isStatusDoneTransition = (
+  oldStatus: string | undefined,
+  newStatus: string | undefined,
+): boolean => oldStatus !== 'done' && newStatus === 'done';

--- a/src/components/chat-panel.vue
+++ b/src/components/chat-panel.vue
@@ -150,6 +150,13 @@ import ContextIndicator from './context-indicator.vue';
 import { ScrollArea } from './ui/scroll-area';
 import { Spinner } from './ui/spinner';
 import { useMessageService } from '@/composables';
+import {
+  isNearBottom as checkIsNearBottom,
+  decideStickOnScroll,
+  shouldRestickOnLengthChange,
+  computeStreamingSignature,
+  isStatusDoneTransition,
+} from '@/common';
 
 const { t } = useI18n();
 const router = useRouter();
@@ -219,21 +226,23 @@ const modelVerified = ref<boolean | null>(null);
 // - Scrolls to bottom on mount, new messages, and content streaming
 // - Stops auto-scrolling when user scrolls up to read history
 // - Resumes when user scrolls back to bottom or sends a message
+// Decision logic lives in src/common/scrollStickiness.ts (pure, unit-tested);
+// this component only wires DOM/rAF/Virtualizer calls to it.
 
-const STICKY_THRESHOLD_PX = 32;
 const stickToBottom = ref(true);
+let lastScrollTop = 0;
+let statusDoneTimer: ReturnType<typeof setTimeout> | undefined;
 
 const getViewport = (): HTMLElement | null => scrollbarRef.value?.viewportElement ?? null;
-
-const isNearBottom = (el: HTMLElement): boolean => {
-  const distance = el.scrollHeight - (el.scrollTop + el.clientHeight);
-  return distance <= STICKY_THRESHOLD_PX;
-};
 
 const handleViewportScroll = () => {
   const el = getViewport();
   if (!el) return;
-  stickToBottom.value = isNearBottom(el);
+  const nearBottom = checkIsNearBottom(el.scrollHeight, el.scrollTop, el.clientHeight);
+  const decision = decideStickOnScroll(el.scrollTop, lastScrollTop, nearBottom);
+  if (decision === 'stick') stickToBottom.value = true;
+  else if (decision === 'release') stickToBottom.value = false;
+  lastScrollTop = el.scrollTop;
 };
 
 let scrollRafId = 0;
@@ -287,21 +296,54 @@ const forceScrollToBottom = () => {
   scrollToLastMessage();
 };
 
-// Scroll on new messages — force to capture layout changes
+// Scroll on new messages — force to capture layout changes.
+// Re-stick ONLY on message append (n > old): a user who scrolled up to read
+// history must not be yanked to the bottom by background length changes.
+// Length decreases (compaction trim / orphaned-streaming-message removal)
+// must not re-stick either — shouldRestickOnLengthChange returns false.
 watch(
   () => props.messages.length,
-  () => requestAnimationFrame(() => scrollToBottomForce()),
+  (n, old) => {
+    if (shouldRestickOnLengthChange(n, old ?? 0)) stickToBottom.value = true;
+    requestAnimationFrame(() => scrollToBottomForce());
+  },
 );
 
-// Scroll on streaming content changes in the last message — batched
+// Scroll on streaming content changes in the last message — batched.
+// The signature covers content/thinking length, message status (streaming →
+// done = answer available), and per-tool-call state (status, result length,
+// confirmation card) so ANY visual growth in the last message scrolls.
 watch(
   () => {
     const msgs = props.messages;
     if (msgs.length === 0) return '';
-    const last = msgs[msgs.length - 1];
-    return `${last.content?.length ?? 0}:${last.thinking?.length ?? 0}:${last.toolCalls?.length ?? 0}`;
+    return computeStreamingSignature(msgs[msgs.length - 1]);
   },
   () => scrollToBottomBatched(),
+);
+
+// When the last message finalizes (status → done), snap to the true bottom
+// via the Virtualizer API and re-scroll once virtua settles its post-measure
+// layout. The 300ms retry catches items taller than the item-size=160 estimate.
+watch(
+  () => {
+    const msgs = props.messages;
+    if (msgs.length === 0) return undefined;
+    return msgs[msgs.length - 1].status;
+  },
+  (newStatus, oldStatus) => {
+    if (isStatusDoneTransition(oldStatus, newStatus) && stickToBottom.value) {
+      scrollToLastMessage();
+      statusDoneTimer = setTimeout(() => scrollToLastMessage(), 300);
+    }
+  },
+);
+
+// ChatPanel persists across session switches (neither parent remounts it via
+// :key / v-if), so onMounted does not re-run — force a scroll per session.
+watch(
+  () => props.sessionId,
+  () => forceScrollToBottom(),
 );
 
 const canSend = computed(() => inputText.value.trim().length > 0 && !props.isLoading);
@@ -419,6 +461,7 @@ onBeforeUnmount(() => {
   el?.removeEventListener('scroll', handleViewportScroll);
   if (scrollRafId) cancelAnimationFrame(scrollRafId);
   clearTimeout(mountRetryTimer);
+  clearTimeout(statusDoneTimer);
 });
 </script>
 

--- a/tests/common/scrollStickiness.test.ts
+++ b/tests/common/scrollStickiness.test.ts
@@ -1,0 +1,207 @@
+import {
+  isNearBottom,
+  decideStickOnScroll,
+  shouldRestickOnLengthChange,
+  computeStreamingSignature,
+  isStatusDoneTransition,
+  STICKY_THRESHOLD_PX,
+  SCROLL_UP_THRESHOLD_PX,
+  type ScrollableMessage,
+} from '../../src/common/scrollStickiness';
+
+describe('isNearBottom', () => {
+  it('returns true when exactly at the bottom (distance 0)', () => {
+    expect(isNearBottom(1000, 600, 400)).toBe(true);
+  });
+
+  it('returns false when scrolled up far from the bottom', () => {
+    expect(isNearBottom(1000, 100, 400)).toBe(false);
+  });
+
+  it('returns true when within the sticky threshold (distance 32)', () => {
+    expect(isNearBottom(1000, 568, 400)).toBe(true);
+  });
+
+  it('returns false just past the sticky threshold (distance 33)', () => {
+    expect(isNearBottom(1000, 567, 400)).toBe(false);
+  });
+
+  it('honors a custom threshold', () => {
+    expect(isNearBottom(1000, 550, 400, 100)).toBe(true);
+    expect(isNearBottom(1000, 490, 400, 100)).toBe(false);
+  });
+
+  it('exposes the sticky threshold constant', () => {
+    expect(STICKY_THRESHOLD_PX).toBe(32);
+  });
+});
+
+describe('decideStickOnScroll', () => {
+  it("returns 'stick' when near the bottom (scroll back resumes auto-scroll)", () => {
+    expect(decideStickOnScroll(568, 100, true)).toBe('stick');
+  });
+
+  it("returns 'release' on genuine upward scroll while not near the bottom", () => {
+    expect(decideStickOnScroll(100, 500, false)).toBe('release');
+  });
+
+  it("returns 'keep' when stationary and not near the bottom (virtua churn)", () => {
+    expect(decideStickOnScroll(500, 500, false)).toBe('keep');
+  });
+
+  it("returns 'keep' on downward scroll while not near the bottom (virtua correction)", () => {
+    expect(decideStickOnScroll(510, 500, false)).toBe('keep');
+  });
+
+  it("returns 'keep' on micro-upward scroll within the threshold (virtua jitter)", () => {
+    expect(decideStickOnScroll(498, 500, false)).toBe('keep');
+  });
+
+  it("gives 'stick' priority over upward movement when near the bottom", () => {
+    expect(decideStickOnScroll(100, 500, true)).toBe('stick');
+  });
+
+  it('honors a custom scroll-up threshold', () => {
+    expect(decideStickOnScroll(490, 500, false, 5)).toBe('release');
+    expect(decideStickOnScroll(490, 500, false, 20)).toBe('keep');
+  });
+
+  it('exposes the scroll-up threshold constant', () => {
+    expect(SCROLL_UP_THRESHOLD_PX).toBe(2);
+  });
+});
+
+describe('shouldRestickOnLengthChange', () => {
+  it('returns true when a message is added', () => {
+    expect(shouldRestickOnLengthChange(5, 4)).toBe(true);
+  });
+
+  it('returns true for the first message', () => {
+    expect(shouldRestickOnLengthChange(1, 0)).toBe(true);
+  });
+
+  it('returns false when a message is removed (compaction/trim)', () => {
+    expect(shouldRestickOnLengthChange(3, 4)).toBe(false);
+  });
+
+  it('returns false when length is unchanged', () => {
+    expect(shouldRestickOnLengthChange(4, 4)).toBe(false);
+  });
+});
+
+describe('computeStreamingSignature', () => {
+  const msg = (partial: Partial<ScrollableMessage>): ScrollableMessage => ({
+    content: '',
+    thinking: '',
+    status: 'streaming',
+    toolCalls: [],
+    ...partial,
+  });
+
+  it('changes when content length grows (streaming)', () => {
+    const before = computeStreamingSignature(msg({ content: 'a'.repeat(10) }));
+    const after = computeStreamingSignature(msg({ content: 'a'.repeat(20) }));
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when thinking length grows', () => {
+    const before = computeStreamingSignature(msg({ thinking: 'a'.repeat(5) }));
+    const after = computeStreamingSignature(msg({ thinking: 'a'.repeat(15) }));
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when a tool result is set (toolCall.result grows)', () => {
+    const before = computeStreamingSignature(
+      msg({ toolCalls: [{ status: 'executing', requiresConfirmation: false }] }),
+    );
+    const after = computeStreamingSignature(
+      msg({
+        toolCalls: [{ status: 'executing', result: 'x'.repeat(100), requiresConfirmation: false }],
+      }),
+    );
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when a tool call status transitions', () => {
+    const before = computeStreamingSignature(
+      msg({ toolCalls: [{ status: 'executing', requiresConfirmation: false }] }),
+    );
+    const after = computeStreamingSignature(
+      msg({ toolCalls: [{ status: 'done', requiresConfirmation: false }] }),
+    );
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when a tool call requires confirmation (confirmation card)', () => {
+    const before = computeStreamingSignature(
+      msg({ toolCalls: [{ status: 'pending', requiresConfirmation: false }] }),
+    );
+    const after = computeStreamingSignature(
+      msg({ toolCalls: [{ status: 'pending', requiresConfirmation: true }] }),
+    );
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when status transitions to done (answer available)', () => {
+    const before = computeStreamingSignature(msg({ status: 'streaming' }));
+    const after = computeStreamingSignature(msg({ status: 'done' }));
+    expect(after).not.toBe(before);
+  });
+
+  it('includes every tool call in the signature', () => {
+    const one = computeStreamingSignature(
+      msg({ toolCalls: [{ status: 'done', requiresConfirmation: false }] }),
+    );
+    const two = computeStreamingSignature(
+      msg({
+        toolCalls: [
+          { status: 'done', requiresConfirmation: false },
+          { status: 'executing', requiresConfirmation: false },
+        ],
+      }),
+    );
+    expect(two).not.toBe(one);
+  });
+
+  it('returns empty string for undefined message', () => {
+    expect(computeStreamingSignature(undefined)).toBe('');
+  });
+
+  it('handles a message without tool calls', () => {
+    expect(computeStreamingSignature(msg({ content: 'hi', status: 'done' }))).toBe('2:0:done:');
+  });
+
+  it('handles an empty message', () => {
+    expect(computeStreamingSignature(msg({}))).toBe('0:0:streaming:');
+  });
+});
+
+describe('isStatusDoneTransition', () => {
+  it('detects streaming → done', () => {
+    expect(isStatusDoneTransition('streaming', 'done')).toBe(true);
+  });
+
+  it('detects pending → done', () => {
+    expect(isStatusDoneTransition('pending', 'done')).toBe(true);
+  });
+
+  it('detects undefined → done (initial load of a done message)', () => {
+    expect(isStatusDoneTransition(undefined, 'done')).toBe(true);
+  });
+
+  it('returns false when already done', () => {
+    expect(isStatusDoneTransition('done', 'done')).toBe(false);
+  });
+
+  it('returns false when transitioning to error', () => {
+    expect(isStatusDoneTransition('streaming', 'error')).toBe(false);
+  });
+
+  it('returns false when staying streaming', () => {
+    expect(isStatusDoneTransition('streaming', 'streaming')).toBe(false);
+  });
+
+  it('returns false when entering streaming from undefined', () => {
+    expect(isStatusDoneTransition(undefined, 'streaming')).toBe(false);
+  });
+});

--- a/tests/manual/scroll-harness.html
+++ b/tests/manual/scroll-harness.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>ChatPanel Scroll Contract Harness</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 24px;
+        background: #f6f7f9;
+        color: #1a1a1a;
+      }
+      h1 {
+        font-size: 18px;
+      }
+      p.sub {
+        color: #555;
+        font-size: 13px;
+        max-width: 720px;
+      }
+      .controls {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin: 12px 0;
+      }
+      button {
+        padding: 6px 12px;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 13px;
+      }
+      button:hover {
+        background: #eee;
+      }
+      #viewport {
+        width: 480px;
+        height: 300px;
+        overflow: auto;
+        border: 1px solid #ccc;
+        border-radius: 8px;
+        background: #fff;
+        padding: 8px;
+        box-sizing: border-box;
+      }
+      .msg {
+        height: 60px;
+        margin-bottom: 8px;
+        border-radius: 6px;
+        background: #e9eef5;
+        padding: 8px;
+        box-sizing: border-box;
+        font-size: 12px;
+        color: #333;
+      }
+      .msg.user {
+        background: #cfe3ff;
+      }
+      .state,
+      .log {
+        margin-top: 12px;
+        font-family: ui-monospace, Menlo, monospace;
+        font-size: 12px;
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        padding: 8px;
+        max-width: 480px;
+      }
+      .state {
+        white-space: pre;
+      }
+      .log {
+        height: 120px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+      }
+      .verdict {
+        margin-top: 8px;
+        font-size: 13px;
+        font-weight: 600;
+      }
+      .verdict.pass {
+        color: #1a7f37;
+      }
+      .verdict.fail {
+        color: #d1242f;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>ChatPanel Scroll Contract Harness</h1>
+    <p class="sub">
+      Exercises the real scroll decision module (<code>/src/common/scrollStickiness.ts</code>) against a
+      real scrollable DOM. The mini controller replicates chat-panel.vue wiring: a native <code>scroll</code>
+      listener feeds <code>decideStickOnScroll</code>, appends call <code>shouldRestickOnLengthChange</code>,
+      and a simulated virtua churn fires a programmatic scroll without user intent.
+    </p>
+
+    <div class="controls">
+      <button id="btn-append" type="button">Append Message</button>
+      <button id="btn-append-user" type="button">Append User Message</button>
+      <button id="btn-remove" type="button">Remove Last Message</button>
+      <button id="btn-tool-result" type="button">Simulate Tool Result Growth (in-place)</button>
+      <button id="btn-churn-down" type="button">Simulate Virtua Churn (scrollTop + 10)</button>
+      <button id="btn-churn-jitter" type="button">Simulate Virtua Jitter (scrollTop - 1)</button>
+      <button id="btn-force" type="button">Force Scroll to Bottom</button>
+      <button id="btn-reset" type="button">Reset</button>
+    </div>
+
+    <div id="viewport" aria-label="chat viewport">
+      <div class="msg user">Initial user message</div>
+      <div class="msg">Initial assistant message</div>
+      <div class="msg user">Second user message</div>
+      <div class="msg">Second assistant message</div>
+    </div>
+
+    <div class="state" id="state">loading…</div>
+    <div class="verdict" id="verdict"></div>
+    <div class="log" id="log"></div>
+
+    <script type="module">
+      import {
+        isNearBottom,
+        decideStickOnScroll,
+        shouldRestickOnLengthChange,
+        computeStreamingSignature,
+        isStatusDoneTransition,
+        STICKY_THRESHOLD_PX,
+      } from '/src/common/scrollStickiness.ts';
+
+      const viewport = document.getElementById('viewport');
+      const stateEl = document.getElementById('state');
+      const logEl = document.getElementById('log');
+      const verdictEl = document.getElementById('verdict');
+
+      let stickToBottom = true;
+      let lastScrollTop = 0;
+      let msgCount = viewport.querySelectorAll('.msg').length;
+
+      const log = line => {
+        const entry = `[${new Date().toISOString().slice(11, 19)}] ${line}`;
+        logEl.textContent = logEl.textContent ? logEl.textContent + '\n' + entry : entry;
+        logEl.scrollTop = logEl.scrollHeight;
+      };
+
+      const render = () => {
+        const distance = viewport.scrollHeight - (viewport.scrollTop + viewport.clientHeight);
+        stateEl.textContent =
+          `stickToBottom: ${stickToBottom}\n` +
+          `scrollTop: ${viewport.scrollTop} / lastScrollTop: ${lastScrollTop}\n` +
+          `scrollHeight: ${viewport.scrollHeight} / clientHeight: ${viewport.clientHeight}\n` +
+          `distanceToBottom: ${distance} (threshold ${STICKY_THRESHOLD_PX})\n` +
+          `isNearBottom: ${isNearBottom(viewport.scrollHeight, viewport.scrollTop, viewport.clientHeight)}\n` +
+          `messageCount: ${msgCount}`;
+      };
+
+      const scrollToBottom = reason => {
+        viewport.scrollTop = viewport.scrollHeight;
+        log(`scrollToBottom (${reason}): scrollTop=${viewport.scrollTop}`);
+        render();
+      };
+
+      const onScroll = () => {
+        const nearBottom = isNearBottom(viewport.scrollHeight, viewport.scrollTop, viewport.clientHeight);
+        const decision = decideStickOnScroll(viewport.scrollTop, lastScrollTop, nearBottom);
+        if (decision === 'stick') stickToBottom = true;
+        else if (decision === 'release') stickToBottom = false;
+        log(`scroll event: scrollTop=${viewport.scrollTop} nearBottom=${nearBottom} → ${decision} (stickToBottom=${stickToBottom})`);
+        lastScrollTop = viewport.scrollTop;
+        render();
+      };
+
+      viewport.addEventListener('scroll', onScroll, { passive: true });
+
+      const appendMessage = user => {
+        const el = document.createElement('div');
+        el.className = 'msg' + (user ? ' user' : '');
+        el.textContent = `${user ? 'User' : 'Assistant'} message ${msgCount + 1}`;
+        viewport.appendChild(el);
+        const oldLen = msgCount;
+        msgCount++;
+        if (shouldRestickOnLengthChange(msgCount, oldLen)) stickToBottom = true;
+        log(`append (len ${oldLen}→${msgCount}): restick=${shouldRestickOnLengthChange(msgCount, oldLen)} stickToBottom=${stickToBottom}`);
+        if (stickToBottom) scrollToBottom('append');
+        render();
+      };
+
+      document.getElementById('btn-append').addEventListener('click', () => appendMessage(false));
+      document.getElementById('btn-append-user').addEventListener('click', () => appendMessage(true));
+
+      document.getElementById('btn-remove').addEventListener('click', () => {
+        const nodes = viewport.querySelectorAll('.msg');
+        if (nodes.length === 0) return;
+        nodes[nodes.length - 1].remove();
+        const oldLen = msgCount;
+        msgCount--;
+        log(`remove (len ${oldLen}→${msgCount}): restick=${shouldRestickOnLengthChange(msgCount, oldLen)}`);
+        render();
+      });
+
+      // Simulates updateToolCallStatus: the last message grows IN PLACE (no
+      // length change). The controller scrolls only when stickToBottom is true,
+      // mirroring chat-panel.vue's scrollToBottomBatched stickToBottom guard.
+      document.getElementById('btn-tool-result').addEventListener('click', () => {
+        const nodes = viewport.querySelectorAll('.msg');
+        if (nodes.length === 0) return;
+        const last = nodes[nodes.length - 1];
+        const grew = last.getAttribute('data-tool-result') !== 'grown';
+        last.setAttribute('data-tool-result', grew ? 'grown' : '');
+        last.style.height = grew ? '140px' : '60px';
+        log(`tool-result in-place growth: ${grew ? 'grow' : 'shrink'} → stickToBottom=${stickToBottom}`);
+        if (grew && stickToBottom) scrollToBottom('tool-result');
+        render();
+      });
+
+      // Simulates virtua's programmatic scrollTop correction WITHOUT user intent.
+      // The harness's own scroll listener must classify it as 'keep' (no release).
+      document.getElementById('btn-churn-down').addEventListener('click', () => {
+        log(`VIRTUA CHURN: programmatic scrollTop += 10 (${viewport.scrollTop} → ${viewport.scrollTop + 10})`);
+        viewport.scrollTop += 10;
+        render();
+      });
+
+      // Simulates virtua's micro-upward jitter (within SCROLL_UP_THRESHOLD_PX=2).
+      document.getElementById('btn-churn-jitter').addEventListener('click', () => {
+        log(`VIRTUA JITTER: programmatic scrollTop -= 1 (${viewport.scrollTop} → ${viewport.scrollTop - 1})`);
+        viewport.scrollTop -= 1;
+        render();
+      });
+
+      document.getElementById('btn-force').addEventListener('click', () => {
+        stickToBottom = true;
+        log(`FORCE: stickToBottom=true`);
+        scrollToBottom('force');
+      });
+
+      document.getElementById('btn-reset').addEventListener('click', () => {
+        stickToBottom = true;
+        lastScrollTop = 0;
+        viewport.scrollTop = 0;
+        log('RESET');
+        render();
+      });
+
+      // Expose test hooks for Playwright.
+      window.__scrollHarness = {
+        get stickToBottom() {
+          return stickToBottom;
+        },
+        get lastScrollTop() {
+          return lastScrollTop;
+        },
+        get scrollTop() {
+          return viewport.scrollTop;
+        },
+        get scrollHeight() {
+          return viewport.scrollHeight;
+        },
+        get isNearBottom() {
+          return isNearBottom(viewport.scrollHeight, viewport.scrollTop, viewport.clientHeight);
+        },
+        appendMessage,
+        removeLast: () => document.getElementById('btn-remove').click(),
+        simulateToolResult: () => document.getElementById('btn-tool-result').click(),
+        churnDown: () => document.getElementById('btn-churn-down').click(),
+        churnJitter: () => document.getElementById('btn-churn-jitter').click(),
+        force: () => document.getElementById('btn-force').click(),
+        scrollTo: y => {
+          viewport.scrollTop = y;
+        },
+        scrollBy: dy => {
+          viewport.scrollTop += dy;
+        },
+        // Pure-module smoke checks exposed for verification
+        pure: {
+          isNearBottom,
+          decideStickOnScroll,
+          shouldRestickOnLengthChange,
+          computeStreamingSignature,
+          isStatusDoneTransition,
+          STICKY_THRESHOLD_PX,
+        },
+      };
+
+      render();
+      log(`harness ready (module loaded, STICKY_THRESHOLD_PX=${STICKY_THRESHOLD_PX})`);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Fixes #477 — in Data Studio (and the shared ChatPanel used by the sidebar), once the message list fills the screen, sending another query produced **no auto-scroll** when the answer arrived: the new answer appeared below the fold and the user had to scroll down manually.

## Root cause (2 layers)

1. **Dominant — `stickToBottom` false-negative.** `handleViewportScroll` flipped `stickToBottom = false` on **every** native scroll event, including virtua's own programmatic corrections (item-add pinning, 160px-estimate→measured size adjustments). Right after `send`, virtua re-laid out the appended messages, the viewport briefly sat >32px above the new bottom, a scroll event fired, and the sticky flag was falsely released — suppressing **every subsequent auto-scroll for the entire run**. This was a regression from `a4735b9` (removed the re-stick-on-length-change safety net).
2. **Secondary — streaming watch key gap.** The key (`content.len : thinking.len : toolCalls.len`) missed growth from tool results (`updateToolCallStatus` mutates fields, not length), confirmation cards (rendered in the Virtualizer slot), and the `status → 'done'` transition — the literal "answer is available" moment.

## Changes

| File | Change |
|---|---|
| `src/common/scrollStickiness.ts` **(new)** | Pure, unit-tested scroll decision logic: `isNearBottom`, `decideStickOnScroll` (releases **only** on genuine upward scroll `>2px` while not near bottom; virtua churn → `'keep'`), `shouldRestickOnLengthChange` (append-only), `computeStreamingSignature` (status + per-tool-call state), `isStatusDoneTransition` |
| `tests/common/scrollStickiness.test.ts` **(new)** | 35 unit tests covering scenarios S2–S13 |
| `src/components/chat-panel.vue` | Harden `handleViewportScroll` (upward-scroll qualification), restore append re-stick, extend streaming signature, add `status → done` final-scroll watcher (+300ms virtua-settle retry), add `sessionId` watcher (ChatPanel persists across session switches), timer cleanup |
| `src/common/index.ts` | Barrel export |
| `tests/manual/scroll-harness.html` **(new)** | Browser harness importing the real module, driven via Playwright for manual QA |
| `AGENTS.md` | ChatPanel scroll contract updated: upward-scroll qualification, new "status → done" + "session switch" rows, virtua-churn failure mode |

## Verification

- Unit tests: **35/35** (RED→GREEN: `Cannot find module` → pass)
- Full suite: **36 suites / 1583 tests PASS**
- `tsc --noEmit` exit 0 · `eslint` exit 0 · `npm run build` exit 0
- Browser harness (Playwright, real DOM): **11/11 PASS** — including the key fix (virtua churn keeps sticky) and S11 (tool-result growth while scrolled up → no scroll)
- Reviewer gate: **APPROVE** (all 14 scenario criteria S1–S14 verified)

Closes #477