### PR TITLE
feat(mcp): expose mongo/dynamo tools to agents + actionable errors

### DIFF
--- a/src-tauri/src/capabilities/dynamo.rs
+++ b/src-tauri/src/capabilities/dynamo.rs
@@ -1266,7 +1266,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Safe,
         "read",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -1294,7 +1294,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Safe,
         "read",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -1321,7 +1321,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Elevated,
         "create",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -1344,7 +1344,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Elevated,
         "create",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -1366,7 +1366,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Elevated,
         "update",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -1383,7 +1383,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Destructive,
         "delete",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!("dynamo__create_gsi", "Create a global secondary index on a DynamoDB table.",
@@ -1398,7 +1398,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
              ("write_capacity_units", "Provisioned write capacity units (integer, for provisioned billing)", false),
              ("warm_throughput", "JSON object with read_units_per_second and write_units_per_second", false),
          ]),
-         RiskLevel::Elevated, "create", &["ui"]);
+         RiskLevel::Elevated, "create", &["agent", "ui"]);
 
     reg!(
         "dynamo__update_gsi",

--- a/src-tauri/src/capabilities/mongo.rs
+++ b/src-tauri/src/capabilities/mongo.rs
@@ -1962,14 +1962,14 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
               ("database", "MongoDB database name", "string", false),
               ("collection", "Collection name", "string", true),
           ]),
-          RiskLevel::Safe, "read", &["ui"]);
+          RiskLevel::Safe, "read", &["agent", "ui"]);
 
     reg!("mongo__database_stats", "Get statistics for a MongoDB database including collection count, object count, and storage metrics.",
           MongoDatabaseStats::new(),
           mongo_schema(&[
               ("database", "MongoDB database name", "string", false),
           ]),
-          RiskLevel::Safe, "read", &["ui"]);
+          RiskLevel::Safe, "read", &["agent", "ui"]);
 
     reg!(
         "mongo__create_database",
@@ -1981,7 +1981,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Elevated,
         "create",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!("mongo__drop_database", "Drop a MongoDB database and all its collections. DESTRUCTIVE: permanently removes all data.",
@@ -1989,7 +1989,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
           mongo_schema(&[
               ("database", "Database name to drop", "string", true),
           ]),
-          RiskLevel::Destructive, "delete", &["ui"]);
+          RiskLevel::Destructive, "delete", &["agent", "ui"]);
 
     reg!("mongo__create_collection", "Create a new collection in a MongoDB database with optional settings (capped, size, max, timeseries, validator).",
           MongoCreateCollection::new(),
@@ -1998,7 +1998,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
               ("collection", "Collection name to create", "string", true),
               ("options", "Optional collection settings {capped, size, max, timeseries, validator}", "object", false),
           ]),
-          RiskLevel::Elevated, "create", &["ui"]);
+          RiskLevel::Elevated, "create", &["agent", "ui"]);
 
     reg!(
         "mongo__drop_collection",
@@ -2010,13 +2010,13 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Destructive,
         "delete",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!("mongo__server_status", "Get MongoDB server status including host, version, uptime, connections, network, and memory usage.",
           MongoServerStatus::new(),
           mongo_schema(&[]),
-          RiskLevel::Safe, "read", &["ui"]);
+          RiskLevel::Safe, "read", &["agent", "ui"]);
 
     reg!(
         "mongo__repl_set_status",
@@ -2025,7 +2025,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         mongo_schema(&[]),
         RiskLevel::Safe,
         "read",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -2035,7 +2035,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         mongo_schema(&[]),
         RiskLevel::Safe,
         "read",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -2088,7 +2088,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Elevated,
         "update",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -2112,7 +2112,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Elevated,
         "create",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!("mongo__truncate_collection", "Remove all documents from a MongoDB collection while preserving the collection and indexes. DESTRUCTIVE: permanently removes all documents.",
@@ -2121,7 +2121,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
               ("database", "MongoDB database name", "string", false),
               ("collection", "Collection name to truncate", "string", true),
           ]),
-          RiskLevel::Destructive, "delete", &["ui"]);
+          RiskLevel::Destructive, "delete", &["agent", "ui"]);
 
     reg!(
         "mongo__list_indexes",
@@ -2133,7 +2133,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Safe,
         "read",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -2171,7 +2171,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Elevated,
         "create",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -2185,7 +2185,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Elevated,
         "delete",
-        &["ui"]
+        &["agent", "ui"]
     );
 
     reg!(
@@ -2204,7 +2204,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Safe,
         "read",
-        &["ui"],
+        &["agent", "ui"],
         true
     );
 }

--- a/src-tauri/src/common/connection_resolver.rs
+++ b/src-tauri/src/common/connection_resolver.rs
@@ -35,7 +35,12 @@ impl ConnectionResolver {
         let connection = all_connections
             .into_iter()
             .find(|c| c.get("id").and_then(|v| v.as_i64()) == Some(id))
-            .ok_or_else(|| format!("Connection '{}' not found in store", connection_id))?;
+            .ok_or_else(|| {
+                format!(
+                    "Connection '{}' not found in store. Connect manually first, or add it in Settings → MCP Bridge.",
+                    connection_id
+                )
+            })?;
 
         normalize_config(connection)
     }


### PR DESCRIPTION
## What

Two changes in the NoSQL MCP surface:

1. **Expose mongo/dynamo tools to agents** — most were tagged `ui`-only, so MCP agents couldn't use them despite the README promising "updates documents, deletes records, creates indexes". ES tools were already agent-tagged. Aligned mongo (16 tools) and dynamo (8 core CRUD/query/index tools) with that baseline. Advanced admin operations (PITR, streams, TTL, backups, table config) stay `ui`-only.
2. **Actionable connection errors** — `ConnectionResolver` now tells the agent to connect manually or enable the connection in Settings → MCP Bridge, matching sqlkit's style.

## Why

- Agent capability gap: README promises agentic document/index operations but the tools were hidden from MCP.
- Error UX: `Connection 'x' not found in store` gave no remediation path.

## Files

- `src-tauri/src/capabilities/mongo.rs` — 16 tools: `ui` → `agent, ui`
- `src-tauri/src/capabilities/dynamo.rs` — 8 tools: `ui` → `agent, ui`
- `src-tauri/src/common/connection_resolver.rs` — error guidance

## Checklist

- [x] `cargo check` passes
- [x] `cargo test --lib` passes (372 tests)