### PR TITLE
feat(mcp): guide agents to dockit tools for NoSQL access

### DIFF
--- a/src-tauri/src/capabilities/dockit.rs
+++ b/src-tauri/src/capabilities/dockit.rs
@@ -93,7 +93,7 @@ impl CapabilityHandler for ListConnections {
 pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
     registry.register(Capability {
         name: "dockit__list_connections",
-        description: "List all configured database connections in DocKit with their name, type, and connection id.",
+        description: "List all configured database connections in DocKit with their name, type, and connection id. Call this when a task needs to access Elasticsearch/MongoDB/DynamoDB to pick the right connection before querying — never fall back to local CLIs (curl/mongosh/aws). Report results in the user's language (中文/English).",
         handler: Arc::new(ListConnections::new()),
         input_schema: serde_json::json!({
             "type": "object",

--- a/src-tauri/src/capabilities/dynamo.rs
+++ b/src-tauri/src/capabilities/dynamo.rs
@@ -1221,7 +1221,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
 
     reg!(
         "dynamo__list_tables",
-        "List all DynamoDB table names in the connected account and region.",
+        "List all DynamoDB table names in the connected account and region. Use this to discover which tables exist before querying. Report results in the user's language (中文/English).",
         DynamoListTables::new(),
         dynamo_schema(&[]),
         RiskLevel::Safe,
@@ -1233,7 +1233,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
 
     reg!(
         "dynamo__query_table",
-        "Query a DynamoDB table using partition key, optional sort key, filters, and pagination.",
+        "Query a DynamoDB table using partition key, optional sort key, filters, and pagination. Use this whenever a task needs DynamoDB data — instead of shelling out to aws CLI. Report results in the user's language (中文/English).",
         DynamoQueryTable::new(),
         dynamo_schema(&[
             ("table_name", "DynamoDB table name", true),

--- a/src-tauri/src/capabilities/es.rs
+++ b/src-tauri/src/capabilities/es.rs
@@ -574,7 +574,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         };
     }
 
-    reg!("es__search", "Execute an Elasticsearch search query using Query DSL. Returns matching documents with scores.", EsSearch,
+    reg!("es__search", "Execute an Elasticsearch search query using Query DSL. Returns matching documents with scores. Use this whenever a task needs data from Elasticsearch/OpenSearch (document counts, content search, aggregations) — instead of shelling out to curl or a local client. Report results in the user's language (中文/English).", EsSearch,
          es_schema(&[("index", "Target index name", "string", true), ("body", "Elasticsearch Query DSL body", "object", true)]),
          RiskLevel::Safe, "read", &["agent"], true);
 
@@ -656,11 +656,11 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         &["agent"]
     );
 
-    reg!("es__cat_indices", "List user indices with health status, document count, and storage size. Results are sorted alphabetically. System/hidden indices (starting with . or _) are ONLY included when the user explicitly asks for them — pass include_system=true. NEVER include system indices in routine listing.", EsCatIndices,
+    reg!("es__cat_indices", "List user indices with health status, document count, and storage size. Results are sorted alphabetically. System/hidden indices (starting with . or _) are ONLY included when the user explicitly asks for them — pass include_system=true. NEVER include system indices in routine listing. Use this to discover which indices exist before searching. Report results in the user's language (中文/English).", EsCatIndices,
          es_schema(&[("include_system", "ONLY set to true when the user explicitly asks for system indices or hidden indices. Default false — system indices are excluded.", "boolean", false)]),
          RiskLevel::Safe, "read", &["agent", "ui"]);
 
-    reg!("es__get_mapping", "Get the field mapping (schema) for an Elasticsearch index, showing field names and data types.", EsGetMapping,
+    reg!("es__get_mapping", "Get the field mapping (schema) for an Elasticsearch index, showing field names and data types. Use this to understand an index's structure before querying. Report results in the user's language (中文/English).", EsGetMapping,
          es_schema(&[("index", "Target index name", "string", true)]),
          RiskLevel::Safe, "read", &["agent"], true);
 

--- a/src-tauri/src/capabilities/mongo.rs
+++ b/src-tauri/src/capabilities/mongo.rs
@@ -1834,14 +1834,14 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         };
     }
 
-    reg!("mongo__list_databases", "List all database names on a MongoDB server. Use this first when no database is known so you can pick one for subsequent calls.",
+    reg!("mongo__list_databases", "List all database names on a MongoDB server. Use this first when no database is known so you can pick one for subsequent calls. Use data_studio/dockit tools for ALL MongoDB access instead of local mongosh CLI. Report results in the user's language (中文/English).",
           MongoListDatabases::new(),
           mongo_schema(&[]),
           RiskLevel::Safe, "read", &["agent", "ui"]);
 
     reg!(
         "mongo__list_collections",
-        "List all collection names in a MongoDB database.",
+        "List all collection names in a MongoDB database. Use this to discover which collections exist before querying. Report results in the user's language (中文/English).",
         MongoListCollections::new(),
         mongo_schema(&[("database", "MongoDB database name", "string", false)]),
         RiskLevel::Safe,
@@ -1851,7 +1851,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
 
     reg!(
         "mongo__find",
-        "Query documents from a MongoDB collection using a filter. Returns matching documents.",
+        "Query documents from a MongoDB collection using a filter. Returns matching documents. Use this whenever a task needs MongoDB data (document counts, content lookup, aggregation of records) — instead of shelling out to mongosh. Report results in the user's language (中文/English).",
         MongoFind::new(),
         mongo_schema(&[
             ("database", "MongoDB database name", "string", false),
@@ -2040,7 +2040,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
 
     reg!(
         "mongo__count_documents",
-        "Count documents in a MongoDB collection matching an optional filter.",
+        "Count documents in a MongoDB collection matching an optional filter. Use this for row-count-style questions instead of fetching all documents. Report results in the user's language (中文/English).",
         MongoCountDocuments::new(),
         mongo_schema(&[
             ("database", "MongoDB database name", "string", false),


### PR DESCRIPTION
## Summary

Strengthens dockit bridge tool descriptions so AI coding agents reach for ES/Mongo/Dynamo tools on any NoSQL task instead of falling back to curl/mongosh/aws CLIs.

## Changes

- `dockit__list_connections` framed as the NoSQL access entry point
- `es__search` / `cat_indices` / `get_mapping`: usage-scenario guidance
- `mongo__list_databases` / `list_collections` / `find` / `count_documents`: usage-scenario guidance
- `dynamo__list_tables` / `query_table` / `scan_table`: usage-scenario guidance
- All ask agents to report results in the user's language (中文/English)

## Testing

- `cargo check` passes