### PR TITLE
feat(mcp): NoSQL discovery workflow guidance + per-connection discover tool

### DIFF
--- a/src-tauri/src/capabilities/dynamo.rs
+++ b/src-tauri/src/capabilities/dynamo.rs
@@ -7,6 +7,7 @@ use data_studio_agent::capabilities::types::{
     Capability, CapabilityHandler, RiskLevel, SourceKind,
 };
 
+use crate::dynamo::batch_get_item::{batch_get_item, BatchGetInput};
 use crate::dynamo::batch_write_item::{batch_write_item, BatchWriteInput};
 use crate::dynamo::cloudwatch_metrics::{get_table_metrics, CloudWatchInput};
 use crate::dynamo::continuous_backups::describe_continuous_backups;
@@ -18,6 +19,7 @@ use crate::dynamo::query_table::{query_table, QueryTableInput};
 use crate::dynamo::scan_table::{scan_table, ScanTableInput};
 use crate::dynamo::time_to_live::describe_time_to_live;
 use crate::dynamo::truncate_table::truncate_table;
+use crate::dynamo::transact_write_items::{transact_write_items, TransactWriteInput};
 use crate::dynamo::update_item::{update_item, UpdateItemInput};
 use crate::dynamo::update_pitr::update_continuous_backups;
 use crate::dynamo::update_streams::update_streams;
@@ -482,6 +484,44 @@ impl CapabilityHandler for DynamoBatchWriteItems {
     }
 }
 
+pub(crate) struct DynamoBatchGetItems {
+    factory: Box<dyn DynamoClientFactory>,
+}
+
+impl DynamoBatchGetItems {
+    pub(crate) fn new() -> Self {
+        Self {
+            factory: Box::new(RealDynamoClientFactory),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_factory(factory: Box<dyn DynamoClientFactory>) -> Self {
+        Self { factory }
+    }
+}
+
+#[async_trait::async_trait]
+impl CapabilityHandler for DynamoBatchGetItems {
+    async fn handle(
+        &self,
+        args: &Value,
+        connection_config: Option<&Value>,
+    ) -> Result<String, String> {
+        let config =
+            connection_config.ok_or_else(|| "DynamoDB requires a connection config".to_string())?;
+        let request_items = args
+            .get("request_items")
+            .ok_or("Missing request_items")?;
+        let client = self.factory.create_client(config).await?;
+        let input = BatchGetInput { request_items };
+        let response = batch_get_item(&client, input).await?;
+        serde_json::to_string(&response)
+            .map(crate::common::format::truncate_tool_output)
+            .map_err(|e| e.to_string())
+    }
+}
+
 pub(crate) struct DynamoUpdateItem {
     factory: Box<dyn DynamoClientFactory>,
 }
@@ -567,6 +607,44 @@ impl CapabilityHandler for DynamoDeleteItem {
             payload: &payload,
         };
         let response = delete_item(&client, input).await?;
+        serde_json::to_string(&response)
+            .map(crate::common::format::truncate_tool_output)
+            .map_err(|e| e.to_string())
+    }
+}
+
+pub(crate) struct DynamoTransactWriteItems {
+    factory: Box<dyn DynamoClientFactory>,
+}
+
+impl DynamoTransactWriteItems {
+    pub(crate) fn new() -> Self {
+        Self {
+            factory: Box::new(RealDynamoClientFactory),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_factory(factory: Box<dyn DynamoClientFactory>) -> Self {
+        Self { factory }
+    }
+}
+
+#[async_trait::async_trait]
+impl CapabilityHandler for DynamoTransactWriteItems {
+    async fn handle(
+        &self,
+        args: &Value,
+        connection_config: Option<&Value>,
+    ) -> Result<String, String> {
+        let config =
+            connection_config.ok_or_else(|| "DynamoDB requires a connection config".to_string())?;
+        let transact_items = args
+            .get("transact_items")
+            .ok_or("Missing transact_items")?;
+        let client = self.factory.create_client(config).await?;
+        let input = TransactWriteInput { transact_items };
+        let response = transact_write_items(&client, input).await?;
         serde_json::to_string(&response)
             .map(crate::common::format::truncate_tool_output)
             .map_err(|e| e.to_string())
@@ -1348,6 +1426,22 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
     );
 
     reg!(
+        "dynamo__batch_get_items",
+        "Batch retrieve multiple items from one or more DynamoDB tables by primary key. Use this to efficiently fetch many items in a single request without scanning or querying each item individually. Example: request_items is a JSON object mapping table names to { keys: [{id: '123'}, {id: '456'}] }.",
+        DynamoBatchGetItems::new(),
+        dynamo_schema(&[
+            (
+                "request_items",
+                "JSON object mapping table names to { keys: [ {attr: val, ...}, ...] }",
+                true
+            ),
+        ]),
+        RiskLevel::Safe,
+        "read",
+        &["agent", "ui"]
+    );
+
+    reg!(
         "dynamo__update_item",
         "Update attributes of an existing DynamoDB item.",
         DynamoUpdateItem::new(),
@@ -1383,6 +1477,22 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         ]),
         RiskLevel::Destructive,
         "delete",
+        &["agent", "ui"]
+    );
+
+    reg!(
+        "dynamo__transact_write_items",
+        "Execute multiple write operations (put, update, delete) in a single ACID transaction across one or more DynamoDB tables. All operations either succeed together or all roll back — ideal for maintaining data consistency across related items. Example: transact_items is a JSON array of objects each with op (put/update/delete), table_name, and operation-specific fields (attributes for put, keys+attributes for update, keys for delete).",
+        DynamoTransactWriteItems::new(),
+        dynamo_schema(&[
+            (
+                "transact_items",
+                "JSON array of transact items, each with op, table_name, and operation-specific fields",
+                true
+            ),
+        ]),
+        RiskLevel::Elevated,
+        "create",
         &["agent", "ui"]
     );
 
@@ -1641,6 +1751,23 @@ mod tests {
         }
     }
 
+    /// Factory that returns a real SDK client backed by dummy credentials.
+    /// Client construction performs no I/O, so module-level argument
+    /// validation runs before any network call is attempted.
+    struct TestDynamoFactory;
+
+    #[async_trait::async_trait]
+    impl DynamoClientFactory for TestDynamoFactory {
+        async fn create_client(&self, _config: &Value) -> Result<aws_sdk_dynamodb::Client, String> {
+            let config = json!({
+                "region": "us-east-1",
+                "accessKeyId": "test",
+                "secretAccessKey": "test",
+            });
+            crate::common::dynamo::create_dynamo_client(&config, None).await
+        }
+    }
+
     // ── Missing connection config ──────────────────────────────────────────
 
     #[tokio::test]
@@ -1689,6 +1816,26 @@ mod tests {
     async fn test_batch_write_items_missing_config() {
         let handler = DynamoBatchWriteItems::new();
         let result = handler.handle(&json!({"table_name": "t"}), None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("connection config"));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_items_missing_config() {
+        let handler = DynamoBatchGetItems::new();
+        let result = handler
+            .handle(&json!({"request_items": {"t": {"keys": []}}}), None)
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("connection config"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_missing_config() {
+        let handler = DynamoTransactWriteItems::new();
+        let result = handler
+            .handle(&json!({"transact_items": []}), None)
+            .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("connection config"));
     }
@@ -1923,6 +2070,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_batch_get_items_missing_request_items() {
+        let handler = DynamoBatchGetItems::new();
+        let result = handler.handle(&json!({}), Some(&json!({}))).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing request_items"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_missing_transact_items() {
+        let handler = DynamoTransactWriteItems::new();
+        let result = handler.handle(&json!({}), Some(&json!({}))).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing transact_items"));
+    }
+
+    #[tokio::test]
     async fn test_update_gsi_missing_table_name() {
         let handler = DynamoUpdateGsi::new();
         let result = handler.handle(&json!({}), Some(&json!({}))).await;
@@ -1983,6 +2146,118 @@ mod tests {
             .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("factory failure"));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_items_factory_error() {
+        let handler = DynamoBatchGetItems::with_factory(Box::new(FailingFactory));
+        let result = handler
+            .handle(
+                &json!({"request_items": {"t": {"keys": []}}}),
+                Some(&json!({"region": "us-east-1"})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("factory failure"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_factory_error() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(FailingFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": []}),
+                Some(&json!({"region": "us-east-1"})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("factory failure"));
+    }
+
+    // ── Parameter format validation (module-level, before SDK call) ────────
+
+    #[tokio::test]
+    async fn test_batch_get_items_rejects_non_object_request_items() {
+        let handler = DynamoBatchGetItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"request_items": [{"t": {"keys": []}}]}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("request_items must be a JSON object"));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_items_rejects_string_request_items() {
+        let handler = DynamoBatchGetItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(&json!({"request_items": "not-an-object"}), Some(&json!({})))
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("request_items must be a JSON object"));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_items_rejects_table_without_keys() {
+        let handler = DynamoBatchGetItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(&json!({"request_items": {"t": {}}}), Some(&json!({})))
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Missing 'keys' array for table 't'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_rejects_unknown_op() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "delete_range", "table_name": "t"}]}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Unknown operation 'delete_range'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_put_missing_attributes() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "put", "table_name": "t"}]}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Missing 'attributes' array for 'put' at index 0"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_delete_missing_keys() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "delete", "table_name": "t"}]}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Missing 'keys' array for 'delete' at index 0"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/capabilities/dynamo.rs
+++ b/src-tauri/src/capabilities/dynamo.rs
@@ -1221,7 +1221,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
 
     reg!(
         "dynamo__list_tables",
-        "List all DynamoDB table names in the connected account and region. Use this to discover which tables exist before querying. Report results in the user's language (中文/English).",
+        "List all DynamoDB table names in the connected account and region. First step for any DynamoDB task: list tables, then describe_table to inspect keys, then query_table. Report results in the user's language (中文/English).",
         DynamoListTables::new(),
         dynamo_schema(&[]),
         RiskLevel::Safe,

--- a/src-tauri/src/capabilities/dynamo.rs
+++ b/src-tauri/src/capabilities/dynamo.rs
@@ -2261,6 +2261,167 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_transact_write_items_empty_items() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(&json!({"transact_items": []}), Some(&json!({})))
+            .await;
+        assert!(result.is_ok());
+        let data: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(data["data"]["consumed_capacity"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_missing_op() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"table_name": "t"}]}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing 'op' field"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_missing_table_name() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "put"}]}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing 'table_name'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_update_missing_keys() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "update", "table_name": "t"}]}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Missing 'keys' array for 'update'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_update_missing_attributes() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "update", "table_name": "t", "keys": []}]}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Missing 'attributes' array for 'update'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_put_sdk_error() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "put", "table_name": "t", "attributes": [{"key": "id", "value": "1", "type": "S"}]}]}),
+                Some(&json!({})),
+            )
+            .await;
+        let data: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(data["status"], 500);
+        assert!(data["message"].as_str().unwrap().contains("Transaction failed"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_update_sdk_error() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "update", "table_name": "t", "keys": [{"key": "id", "value": "1", "type": "S"}], "attributes": [{"key": "name", "value": "test", "type": "S"}]}]}),
+                Some(&json!({})),
+            )
+            .await;
+        let data: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(data["status"], 500);
+        assert!(data["message"].as_str().unwrap().contains("Transaction failed"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_items_delete_sdk_error() {
+        let handler = DynamoTransactWriteItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"transact_items": [{"op": "delete", "table_name": "t", "keys": [{"key": "id", "value": "1", "type": "S"}]}]}),
+                Some(&json!({})),
+            )
+            .await;
+        let data: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(data["status"], 500);
+        assert!(data["message"].as_str().unwrap().contains("Transaction failed"));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_items_empty_request() {
+        let handler = DynamoBatchGetItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(&json!({"request_items": {}}), Some(&json!({})))
+            .await;
+        let data: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(data["status"], 200);
+        assert_eq!(data["data"]["responses"].as_object().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_items_all_empty_keys() {
+        let handler = DynamoBatchGetItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"request_items": {"t1": {"keys": []}, "t2": {"keys": []}}}),
+                Some(&json!({})),
+            )
+            .await;
+        let data: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(data["status"], 200);
+        assert_eq!(data["message"], "No valid keys provided");
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_items_sdk_error() {
+        let handler = DynamoBatchGetItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"request_items": {"t": {"keys": [{"id": "1"}]}}}),
+                Some(&json!({})),
+            )
+            .await;
+        let data: Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(data["status"], 500);
+        assert!(data["message"].as_str().unwrap().contains("Failed to batch get items"));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_items_rejects_non_object_key() {
+        let handler = DynamoBatchGetItems::with_factory(Box::new(TestDynamoFactory));
+        let result = handler
+            .handle(
+                &json!({"request_items": {"t": {"keys": ["not-an-object"]}}}),
+                Some(&json!({})),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Each key must be a JSON object"));
+    }
+
+    #[tokio::test]
     async fn test_update_gsi_factory_error() {
         let handler = DynamoUpdateGsi::with_factory(Box::new(FailingFactory));
         let result = handler

--- a/src-tauri/src/capabilities/es.rs
+++ b/src-tauri/src/capabilities/es.rs
@@ -158,6 +158,9 @@ pub(crate) struct EsGetAlias;
 pub(crate) struct EsPutAlias;
 pub(crate) struct EsDeleteAlias;
 pub(crate) struct EsUpdateAliases;
+pub(crate) struct EsBulk;
+pub(crate) struct EsCount;
+pub(crate) struct EsReindex;
 
 macro_rules! impl_es_handler {
     ($struct:ty, $method:expr, $path_fn:expr, $has_body:expr) => {
@@ -521,6 +524,61 @@ impl_es_handler!(
     true
 );
 
+#[async_trait::async_trait]
+impl CapabilityHandler for EsBulk {
+    async fn handle(
+        &self,
+        args: &Value,
+        connection_config: Option<&Value>,
+    ) -> Result<String, String> {
+        let config = connection_config
+            .ok_or_else(|| "ES requires a connection config".to_string())?;
+        let index = args
+            .get("index")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Missing index".to_string())?;
+        crate::common::validation::validate_index_name(index, false)?;
+        let body = args
+            .get("body")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Missing body (NDJSON bulk operations)".to_string())?;
+        let path = format!(
+            "/{}/_bulk",
+            crate::common::validation::url_encode_segment(index)
+        );
+        execute_es_http("POST", &path, Some(body), config, None).await
+    }
+}
+
+impl_es_handler!(
+    EsCount,
+    "POST",
+    |args: &Value| -> Result<String, String> {
+        match args
+            .get("index")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            Some(index) => {
+                crate::common::validation::validate_index_name(index, true)?;
+                Ok(format!(
+                    "/{}/_count",
+                    crate::common::validation::url_encode_segment(index)
+                ))
+            }
+            None => Ok("/_count".to_string()),
+        }
+    },
+    true
+);
+
+impl_es_handler!(
+    EsReindex,
+    "POST",
+    |_args: &Value| -> Result<String, String> { Ok("/_reindex".to_string()) },
+    true
+);
+
 // ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
@@ -754,6 +812,18 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
     reg!("es__update_aliases", "Atomically add and/or remove multiple aliases in a single operation using the _aliases endpoint.", EsUpdateAliases,
          es_schema(&[("body", "Alias actions body", "object", true)]),
          RiskLevel::Elevated, "update", &["agent"]);
+
+    reg!("es__bulk", "Execute bulk index/create/update/delete operations in a single request using the NDJSON _bulk endpoint.\n\nUse when you need to batch multiple document operations (index, create, update, delete) for performance — instead of calling index_document/update_document/delete_document individually.\n\nExample: {\"index\": \"orders\", \"body\": \"{\\\"index\\\":{\\\"_id\\\":\\\"1\\\"}}\\n{\\\"status\\\":\\\"shipped\\\"}\\n{\\\"delete\\\":{\\\"_id\\\":\\\"2\\\"}}\\n\"}.", EsBulk,
+         es_schema(&[("index", "Target index name", "string", true), ("body", "NDJSON bulk operations body — one action+metadata line per operation, an optional source line for writes, separated by newlines", "string", true)]),
+         RiskLevel::Elevated, "create", &["agent"]);
+
+    reg!("es__count", "Count documents in an Elasticsearch index, optionally matching a query. Supports wildcard patterns and counting across all indices.\n\nUse when you need a quick document count (with optional query filter) — instead of running a full search and checking hits.total.value.\n\nExample: {\"index\": \"orders*\", \"body\": {\"query\": {\"term\": {\"status\": \"shipped\"}}}}.", EsCount,
+         es_schema(&[("index", "Target index name or pattern (supports wildcards, e.g. orders*). Omit to count all indices.", "string", false), ("body", "Optional Elasticsearch query DSL to filter documents before counting", "object", false)]),
+         RiskLevel::Safe, "read", &["agent"], true);
+
+    reg!("es__reindex", "Copy documents from one index to another using the _reindex API, with optional query filtering and script transformations.\n\nUse when migrating data between indices, changing mappings, reindexing a subset of documents, or copying data to a new index.\n\nExample: {\"body\": {\"source\": {\"index\": \"old-orders\"}, \"dest\": {\"index\": \"new-orders\"}}}.", EsReindex,
+         es_schema(&[("body", "Reindex request body with source.index and dest.index", "object", true)]),
+         RiskLevel::Elevated, "create", &["agent"]);
 }
 
 #[cfg(test)]
@@ -1462,6 +1532,9 @@ mod tests {
         assert!(reg.get("es__put_alias").is_some());
         assert!(reg.get("es__delete_alias").is_some());
         assert!(reg.get("es__update_aliases").is_some());
+        assert!(reg.get("es__bulk").is_some());
+        assert!(reg.get("es__count").is_some());
+        assert!(reg.get("es__reindex").is_some());
 
         let all_agent = reg.agent_tools();
         let es_agent: Vec<_> = all_agent
@@ -1470,8 +1543,162 @@ mod tests {
             .collect();
         assert_eq!(
             es_agent.len(),
-            16,
-            "expected 16 ES capabilities tagged for agent"
+            19,
+            "expected 19 ES capabilities tagged for agent"
         );
+    }
+
+    // ---- EsBulk ----
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_es_bulk_via_wiremock() {
+        use super::{CapabilityHandler, EsBulk};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/my-index/_bulk"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"errors":false,"items":[{"index":{"_id":"1","result":"created"}},{"delete":{"_id":"2","result":"deleted"}}]}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let handler = EsBulk;
+        let body = "{\"index\":{\"_id\":\"1\"}}\n{\"title\":\"hello\"}\n{\"delete\":{\"_id\":\"2\"}}\n";
+        let args = serde_json::json!({"index": "my-index", "body": body});
+        let result = handler.handle(&args, Some(&mock_config(&server))).await;
+        assert!(result.is_ok(), "got: {:?}", result.err());
+        assert!(result.unwrap().contains("items"));
+    }
+
+    #[tokio::test]
+    async fn test_es_bulk_missing_index() {
+        use super::{CapabilityHandler, EsBulk};
+        let handler = EsBulk;
+        let config = serde_json::json!({"host": "http://localhost", "port": 9200});
+        let args = serde_json::json!({"body": "{}"});
+        let result = handler.handle(&args, Some(&config)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing index"));
+    }
+
+    #[tokio::test]
+    async fn test_es_bulk_missing_body() {
+        use super::{CapabilityHandler, EsBulk};
+        let handler = EsBulk;
+        let config = serde_json::json!({"host": "http://localhost", "port": 9200});
+        let args = serde_json::json!({"index": "my-index"});
+        let result = handler.handle(&args, Some(&config)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing body"));
+    }
+
+    // ---- EsCount ----
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_es_count_with_index_via_wiremock() {
+        use super::{CapabilityHandler, EsCount};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/my-index/_count"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(r#"{"count":42,"_shards":{"total":1,"successful":1}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let handler = EsCount;
+        let args = serde_json::json!({"index": "my-index"});
+        let result = handler.handle(&args, Some(&mock_config(&server))).await;
+        assert!(result.is_ok(), "got: {:?}", result.err());
+        assert!(result.unwrap().contains("count"));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_es_count_all_indices_via_wiremock() {
+        use super::{CapabilityHandler, EsCount};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/_count"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(r#"{"count":100,"_shards":{"total":5,"successful":5}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let handler = EsCount;
+        let args = serde_json::json!({});
+        let result = handler.handle(&args, Some(&mock_config(&server))).await;
+        assert!(result.is_ok(), "got: {:?}", result.err());
+        assert!(result.unwrap().contains("count"));
+    }
+
+    // ---- EsReindex ----
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_es_reindex_via_wiremock() {
+        use super::{CapabilityHandler, EsReindex};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/_reindex"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"took":123,"total":10,"created":10,"batches":1}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let handler = EsReindex;
+        let args = serde_json::json!({"body": {"source": {"index": "old-index"}, "dest": {"index": "new-index"}}});
+        let result = handler.handle(&args, Some(&mock_config(&server))).await;
+        assert!(result.is_ok(), "got: {:?}", result.err());
+        assert!(result.unwrap().contains("created"));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn test_es_reindex_missing_body() {
+        use super::{CapabilityHandler, EsReindex};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // The reindex handler does not validate `body` itself — a missing body is
+        // forwarded as-is and rejected by ES with a 400. Verify the handler
+        // surfaces ES's rejection instead of failing on the missing argument.
+        Mock::given(method("POST"))
+            .and(path("/_reindex"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string(r#"{"error":{"reason":"request body is required"}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let handler = EsReindex;
+        let args = serde_json::json!({});
+        let result = handler.handle(&args, Some(&mock_config(&server))).await;
+        assert!(
+            result.is_ok(),
+            "missing body must not error locally, got: {:?}",
+            result.err()
+        );
+        assert!(result.unwrap().contains("400"));
     }
 }

--- a/src-tauri/src/capabilities/es.rs
+++ b/src-tauri/src/capabilities/es.rs
@@ -656,7 +656,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         &["agent"]
     );
 
-    reg!("es__cat_indices", "List user indices with health status, document count, and storage size. Results are sorted alphabetically. System/hidden indices (starting with . or _) are ONLY included when the user explicitly asks for them — pass include_system=true. NEVER include system indices in routine listing. Use this to discover which indices exist before searching. Report results in the user's language (中文/English).", EsCatIndices,
+    reg!("es__cat_indices", "List user indices with health status, document count, and storage size. Results are sorted alphabetically. System/hidden indices (starting with . or _) are ONLY included when the user explicitly asks for them — pass include_system=true. NEVER include system indices in routine listing. First step for any Elasticsearch task: list indices, then get_mapping to inspect structure, then search. Report results in the user's language (中文/English).", EsCatIndices,
          es_schema(&[("include_system", "ONLY set to true when the user explicitly asks for system indices or hidden indices. Default false — system indices are excluded.", "boolean", false)]),
          RiskLevel::Safe, "read", &["agent", "ui"]);
 

--- a/src-tauri/src/capabilities/mongo.rs
+++ b/src-tauri/src/capabilities/mongo.rs
@@ -476,6 +476,74 @@ impl MongoSampleDocuments {
     }
 }
 
+pub(crate) struct MongoInsertMany {
+    factory: Box<dyn MongoClientFactory>,
+}
+
+impl MongoInsertMany {
+    pub(crate) fn new() -> Self {
+        Self {
+            factory: Box::new(RealMongoClientFactory),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_factory(factory: Box<dyn MongoClientFactory>) -> Self {
+        Self { factory }
+    }
+}
+
+pub(crate) struct MongoFindOneAndUpdate {
+    factory: Box<dyn MongoClientFactory>,
+}
+
+impl MongoFindOneAndUpdate {
+    pub(crate) fn new() -> Self {
+        Self {
+            factory: Box::new(RealMongoClientFactory),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_factory(factory: Box<dyn MongoClientFactory>) -> Self {
+        Self { factory }
+    }
+}
+
+pub(crate) struct MongoBulkWrite {
+    factory: Box<dyn MongoClientFactory>,
+}
+
+impl MongoBulkWrite {
+    pub(crate) fn new() -> Self {
+        Self {
+            factory: Box::new(RealMongoClientFactory),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_factory(factory: Box<dyn MongoClientFactory>) -> Self {
+        Self { factory }
+    }
+}
+
+pub(crate) struct MongoDistinct {
+    factory: Box<dyn MongoClientFactory>,
+}
+
+impl MongoDistinct {
+    pub(crate) fn new() -> Self {
+        Self {
+            factory: Box::new(RealMongoClientFactory),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_factory(factory: Box<dyn MongoClientFactory>) -> Self {
+        Self { factory }
+    }
+}
+
 #[async_trait::async_trait]
 impl CapabilityHandler for MongoListDatabases {
     async fn handle(
@@ -1782,6 +1850,317 @@ impl CapabilityHandler for MongoSampleDocuments {
 }
 
 // ---------------------------------------------------------------------------
+// insert_many handler
+// ---------------------------------------------------------------------------
+
+#[async_trait::async_trait]
+impl CapabilityHandler for MongoInsertMany {
+    async fn handle(
+        &self,
+        args: &Value,
+        connection_config: Option<&Value>,
+    ) -> Result<String, String> {
+        let config =
+            connection_config.ok_or_else(|| "MongoDB requires a connection config".to_string())?;
+        let (client, _) = self.factory.create_client(config).await?;
+        let db_name = get_db_name(args, config)?;
+        let collection_name = args
+            .get("collection")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing collection")?;
+        let docs_val = args
+            .get("documents")
+            .and_then(|v| v.as_array())
+            .ok_or("Missing or invalid documents array")?;
+        let docs: Vec<Document> = docs_val
+            .iter()
+            .map(crate::common::bson::json_to_bson_doc_agent)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let db = client.database(&db_name);
+        let coll = db.collection::<Document>(collection_name);
+        let result = coll
+            .insert_many(docs)
+            .await
+            .map_err(|e| format!("insert_many failed: {}", e))?;
+        let inserted_ids: Value = result
+            .inserted_ids
+            .iter()
+            .map(|(k, v)| {
+                (k.to_string(), crate::common::bson::bson_to_value(v))
+            })
+            .collect::<serde_json::Map<_, _>>()
+            .into();
+        let data = serde_json::json!({
+            "inserted_count": result.inserted_ids.len(),
+            "inserted_ids": inserted_ids,
+        });
+        Ok(ApiResponse::json(data).into_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// find_one_and_update handler
+// ---------------------------------------------------------------------------
+
+#[async_trait::async_trait]
+impl CapabilityHandler for MongoFindOneAndUpdate {
+    async fn handle(
+        &self,
+        args: &Value,
+        connection_config: Option<&Value>,
+    ) -> Result<String, String> {
+        let config =
+            connection_config.ok_or_else(|| "MongoDB requires a connection config".to_string())?;
+        let (client, _) = self.factory.create_client(config).await?;
+        let db_name = get_db_name(args, config)?;
+        let collection_name = args
+            .get("collection")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing collection")?;
+        let filter_val = args.get("filter").ok_or("Missing filter")?;
+        let update_val = args.get("update").ok_or("Missing update")?;
+        let filter = crate::common::bson::json_to_bson_doc_agent(filter_val)?;
+        let update = crate::common::bson::json_to_bson_doc_agent(update_val)?;
+
+        let db = client.database(&db_name);
+        let coll = db.collection::<Document>(collection_name);
+
+        let return_doc = args
+            .get("options")
+            .and_then(|o| o.get("return_document"))
+            .and_then(|v| v.as_str());
+        let upsert = args
+            .get("options")
+            .and_then(|o| o.get("upsert"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let sort_val = args
+            .get("options")
+            .and_then(|o| o.get("sort"));
+
+        let mut builder = coll.find_one_and_update(filter, update);
+        match return_doc {
+            Some("after") => {
+                builder = builder.return_document(mongodb::options::ReturnDocument::After);
+            }
+            _ => {}
+        }
+        if upsert {
+            builder = builder.upsert(true);
+        }
+        if let Some(sort) = sort_val {
+            let sort_doc = crate::common::bson::json_to_bson_doc_agent(sort)?;
+            builder = builder.sort(sort_doc);
+        }
+
+        let result_doc = builder
+            .await
+            .map_err(|e| format!("find_one_and_update failed: {}", e))?;
+
+        match result_doc {
+            Some(doc) => {
+                let data = serde_json::json!({
+                    "document": crate::common::bson::bson_to_value(&mongodb::bson::Bson::Document(doc)),
+                });
+                Ok(ApiResponse::json(data).into_string())
+            }
+            None => {
+                let data = serde_json::json!({ "document": null });
+                Ok(ApiResponse::json(data).into_string())
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// bulk_write handler
+// ---------------------------------------------------------------------------
+
+#[async_trait::async_trait]
+impl CapabilityHandler for MongoBulkWrite {
+    async fn handle(
+        &self,
+        args: &Value,
+        connection_config: Option<&Value>,
+    ) -> Result<String, String> {
+        let config =
+            connection_config.ok_or_else(|| "MongoDB requires a connection config".to_string())?;
+        let (client, _) = self.factory.create_client(config).await?;
+        let db_name = get_db_name(args, config)?;
+        let collection_name = args
+            .get("collection")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing collection")?;
+        let ops_val = args
+            .get("operations")
+            .and_then(|v| v.as_array())
+            .ok_or("Missing or invalid operations array")?;
+
+        let db = client.database(&db_name);
+        let coll = db.collection::<Document>(collection_name);
+        let ns = coll.namespace();
+
+        let mut models: Vec<mongodb::options::WriteModel> = Vec::new();
+
+        for op in ops_val {
+            let op_type = op
+                .get("op")
+                .and_then(|v| v.as_str())
+                .ok_or("Each operation must have an 'op' field")?;
+
+            match op_type {
+                "insert_one" => {
+                    let doc_val = op
+                        .get("document")
+                        .ok_or("insert_one operation missing 'document'")?;
+                    let doc = crate::common::bson::json_to_bson_doc_agent(doc_val)?;
+                    models.push(mongodb::options::WriteModel::InsertOne(
+                        mongodb::options::InsertOneModel::builder()
+                            .namespace(ns.clone())
+                            .document(doc)
+                            .build(),
+                    ));
+                }
+                "update_one" => {
+                    let filter_val = op.get("filter").ok_or("update_one missing 'filter'")?;
+                    let update_val = op.get("update").ok_or("update_one missing 'update'")?;
+                    let filter = crate::common::bson::json_to_bson_doc_agent(filter_val)?;
+                    let update = crate::common::bson::json_to_bson_doc_agent(update_val)?;
+                    let model = if let Some(true) =
+                        op.get("upsert").and_then(|v| v.as_bool())
+                    {
+                        mongodb::options::UpdateOneModel::builder()
+                            .namespace(ns.clone())
+                            .filter(filter)
+                            .update(update)
+                            .upsert(true)
+                            .build()
+                    } else {
+                        mongodb::options::UpdateOneModel::builder()
+                            .namespace(ns.clone())
+                            .filter(filter)
+                            .update(update)
+                            .build()
+                    };
+                    models.push(mongodb::options::WriteModel::UpdateOne(model));
+                }
+                "update_many" => {
+                    let filter_val =
+                        op.get("filter").ok_or("update_many missing 'filter'")?;
+                    let update_val =
+                        op.get("update").ok_or("update_many missing 'update'")?;
+                    let filter = crate::common::bson::json_to_bson_doc_agent(filter_val)?;
+                    let update = crate::common::bson::json_to_bson_doc_agent(update_val)?;
+                    let model = if let Some(true) =
+                        op.get("upsert").and_then(|v| v.as_bool())
+                    {
+                        mongodb::options::UpdateManyModel::builder()
+                            .namespace(ns.clone())
+                            .filter(filter)
+                            .update(update)
+                            .upsert(true)
+                            .build()
+                    } else {
+                        mongodb::options::UpdateManyModel::builder()
+                            .namespace(ns.clone())
+                            .filter(filter)
+                            .update(update)
+                            .build()
+                    };
+                    models.push(mongodb::options::WriteModel::UpdateMany(model));
+                }
+                "delete_one" => {
+                    let filter_val =
+                        op.get("filter").ok_or("delete_one missing 'filter'")?;
+                    let filter = crate::common::bson::json_to_bson_doc_agent(filter_val)?;
+                    models.push(mongodb::options::WriteModel::DeleteOne(
+                        mongodb::options::DeleteOneModel::builder()
+                            .namespace(ns.clone())
+                            .filter(filter)
+                            .build(),
+                    ));
+                }
+                "delete_many" => {
+                    let filter_val =
+                        op.get("filter").ok_or("delete_many missing 'filter'")?;
+                    let filter = crate::common::bson::json_to_bson_doc_agent(filter_val)?;
+                    models.push(mongodb::options::WriteModel::DeleteMany(
+                        mongodb::options::DeleteManyModel::builder()
+                            .namespace(ns.clone())
+                            .filter(filter)
+                            .build(),
+                    ));
+                }
+                _ => {
+                    return Err(format!("Unknown operation type: {}", op_type));
+                }
+            }
+        }
+
+        let result = client
+            .bulk_write(models)
+            .await
+            .map_err(|e| format!("bulk_write failed: {}", e))?;
+
+        let data = serde_json::json!({
+            "inserted_count": result.inserted_count,
+            "upserted_count": result.upserted_count,
+            "modified_count": result.modified_count,
+            "deleted_count": result.deleted_count,
+        });
+        Ok(ApiResponse::json(data).into_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// distinct handler
+// ---------------------------------------------------------------------------
+
+#[async_trait::async_trait]
+impl CapabilityHandler for MongoDistinct {
+    async fn handle(
+        &self,
+        args: &Value,
+        connection_config: Option<&Value>,
+    ) -> Result<String, String> {
+        let config =
+            connection_config.ok_or_else(|| "MongoDB requires a connection config".to_string())?;
+        let (client, _) = self.factory.create_client(config).await?;
+        let db_name = get_db_name(args, config)?;
+        let collection_name = args
+            .get("collection")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing collection")?;
+        let field = args
+            .get("field")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing field")?;
+        let filter = args
+            .get("filter")
+            .map(crate::common::bson::json_to_bson_doc_agent)
+            .transpose()?
+            .unwrap_or_else(|| doc! {});
+
+        let db = client.database(&db_name);
+        let coll = db.collection::<Document>(collection_name);
+        let values: Vec<Value> = coll
+            .distinct(field, filter)
+            .await
+            .map_err(|e| format!("distinct failed: {}", e))?
+            .iter()
+            .map(crate::common::bson::bson_to_value)
+            .collect();
+
+        let data = serde_json::json!({
+            "field": field,
+            "values": values,
+        });
+        Ok(ApiResponse::json(data).into_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
 
@@ -2199,6 +2578,101 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
                 "limit",
                 "Maximum number of documents to return (default 10, max 1000)",
                 "integer",
+                false
+            ),
+        ]),
+        RiskLevel::Safe,
+        "read",
+        &["agent", "ui"],
+        true
+    );
+
+    reg!(
+        "mongo__insert_many",
+        "Insert multiple documents into a MongoDB collection in a single round trip.\n\nUse when you need to insert several documents at once — more efficient than multiple insert_one calls for bulk inserts.\n\nExample: {\"database\": \"app\", \"collection\": \"users\", \"documents\": [{\"name\": \"Alice\"}, {\"name\": \"Bob\"}]}.",
+        MongoInsertMany::new(),
+        mongo_schema(&[
+            ("database", "MongoDB database name", "string", false),
+            ("collection", "Collection name", "string", true),
+            (
+                "documents",
+                "Array of documents to insert",
+                "array",
+                true
+            ),
+        ]),
+        RiskLevel::Elevated,
+        "create",
+        &["agent", "ui"]
+    );
+
+    reg!(
+        "mongo__find_one_and_update",
+        "Find a single document in a MongoDB collection, update it atomically, and return either the original or updated version.\n\nUse when you need to atomically read and modify a document — e.g., increment a counter, claim a task, or reserve a resource.\n\nExample: {\"database\": \"app\", \"collection\": \"tasks\", \"filter\": {\"status\": \"pending\"}, \"update\": {\"$set\": {\"status\": \"processing\"}}, \"options\": {\"return_document\": \"after\", \"sort\": {\"priority\": 1}}}.",
+        MongoFindOneAndUpdate::new(),
+        mongo_schema(&[
+            ("database", "MongoDB database name", "string", false),
+            ("collection", "Collection name", "string", true),
+            (
+                "filter",
+                "Query filter to match the document to update",
+                "object",
+                true
+            ),
+            (
+                "update",
+                "Update operations, e.g. {\"$set\": {\"status\": \"done\"}}",
+                "object",
+                true
+            ),
+            (
+                "options",
+                "Optional settings: {return_document: \"before\"|\"after\", upsert: bool, sort: object}",
+                "object",
+                false
+            ),
+        ]),
+        RiskLevel::Elevated,
+        "update",
+        &["agent"]
+    );
+
+    reg!(
+        "mongo__bulk_write",
+        "Execute multiple write operations (insert, update, delete) in a single round trip to a MongoDB collection.\n\nUse when you need to batch mixed write operations — insert some docs, update others, delete some — all in one efficient call. Supports insert_one, update_one, update_many, delete_one, delete_many.\n\nExample: {\"database\": \"app\", \"collection\": \"logs\", \"operations\": [{\"op\": \"insert_one\", \"document\": {\"msg\": \"start\"}}, {\"op\": \"delete_many\", \"filter\": {\"level\": \"debug\"}}]}.",
+        MongoBulkWrite::new(),
+        mongo_schema(&[
+            ("database", "MongoDB database name", "string", false),
+            ("collection", "Collection name", "string", true),
+            (
+                "operations",
+                "Array of operations. Each has 'op' field: insert_one (needs 'document'), update_one/update_many (needs 'filter','update', optional 'upsert'), delete_one/delete_many (needs 'filter')",
+                "array",
+                true
+            ),
+        ]),
+        RiskLevel::Elevated,
+        "write",
+        &["agent"]
+    );
+
+    reg!(
+        "mongo__distinct",
+        "Get the distinct values for a specific field across a MongoDB collection, optionally filtered.\n\nUse when you need to enumerate all unique values of a field — e.g., list all categories, tags, or status codes used in a collection.\n\nExample: {\"database\": \"app\", \"collection\": \"products\", \"field\": \"category\", \"filter\": {\"active\": true}}.",
+        MongoDistinct::new(),
+        mongo_schema(&[
+            ("database", "MongoDB database name", "string", false),
+            ("collection", "Collection name", "string", true),
+            (
+                "field",
+                "Field name to find distinct values for",
+                "string",
+                true
+            ),
+            (
+                "filter",
+                "Optional query filter to narrow results",
+                "object",
                 false
             ),
         ]),
@@ -2757,6 +3231,138 @@ mod tests {
     async fn test_mongo_repl_set_status_factory_error() {
         let handler = MongoReplSetStatus::with_factory(Box::new(err_factory()));
         let result = handler.handle(&json!({}), Some(&mock_config())).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("factory error"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_insert_many_missing_documents() {
+        let cl = lazy_client();
+        let handler = MongoInsertMany::with_factory(Box::new(ok_factory(cl)));
+        let result = handler
+            .handle(&json!({"collection": "c"}), Some(&mock_config()))
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Missing or invalid documents array"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_insert_many_missing_config() {
+        let handler = MongoInsertMany::new();
+        let result = handler.handle(&json!({}), None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("connection config"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_insert_many_factory_error() {
+        let handler = MongoInsertMany::with_factory(Box::new(err_factory()));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "documents": [{"x": 1}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("factory error"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_find_one_and_update_missing_filter() {
+        let cl = lazy_client();
+        let handler = MongoFindOneAndUpdate::with_factory(Box::new(ok_factory(cl)));
+        let result = handler
+            .handle(&json!({"collection": "c"}), Some(&mock_config()))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing filter"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_find_one_and_update_missing_config() {
+        let handler = MongoFindOneAndUpdate::new();
+        let result = handler.handle(&json!({}), None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("connection config"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_find_one_and_update_factory_error() {
+        let handler = MongoFindOneAndUpdate::with_factory(Box::new(err_factory()));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "filter": {}, "update": {"$set": {"a": 1}}}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("factory error"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_missing_operations() {
+        let cl = lazy_client();
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(cl)));
+        let result = handler
+            .handle(&json!({"collection": "c"}), Some(&mock_config()))
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Missing or invalid operations array"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_missing_config() {
+        let handler = MongoBulkWrite::new();
+        let result = handler.handle(&json!({}), None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("connection config"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_factory_error() {
+        let handler = MongoBulkWrite::with_factory(Box::new(err_factory()));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "operations": [{"op": "insert_one", "document": {"x": 1}}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("factory error"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_distinct_missing_field() {
+        let cl = lazy_client();
+        let handler = MongoDistinct::with_factory(Box::new(ok_factory(cl)));
+        let result = handler
+            .handle(&json!({"collection": "c"}), Some(&mock_config()))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing field"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_distinct_missing_config() {
+        let handler = MongoDistinct::new();
+        let result = handler.handle(&json!({}), None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("connection config"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_distinct_factory_error() {
+        let handler = MongoDistinct::with_factory(Box::new(err_factory()));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "field": "category"}),
+                Some(&mock_config()),
+            )
+            .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("factory error"));
     }

--- a/src-tauri/src/capabilities/mongo.rs
+++ b/src-tauri/src/capabilities/mongo.rs
@@ -1834,7 +1834,7 @@ pub(crate) fn register_all(registry: &mut CapabilityRegistry) {
         };
     }
 
-    reg!("mongo__list_databases", "List all database names on a MongoDB server. Use this first when no database is known so you can pick one for subsequent calls. Use data_studio/dockit tools for ALL MongoDB access instead of local mongosh CLI. Report results in the user's language (中文/English).",
+    reg!("mongo__list_databases", "List all database names on a MongoDB server. Use this first when no database is known so you can pick one for subsequent calls. First step for any MongoDB task: list databases, then list_collections, then find. Use data_studio/dockit tools for ALL MongoDB access instead of local mongosh CLI. Report results in the user's language (中文/English).",
           MongoListDatabases::new(),
           mongo_schema(&[]),
           RiskLevel::Safe, "read", &["agent", "ui"]);

--- a/src-tauri/src/capabilities/mongo.rs
+++ b/src-tauri/src/capabilities/mongo.rs
@@ -3366,4 +3366,139 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("factory error"));
     }
+
+    #[tokio::test]
+    async fn test_mongo_insert_many_missing_collection() {
+        let handler = MongoInsertMany::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(&json!({"documents": []}), Some(&mock_config()))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing collection"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_find_one_and_update_missing_collection() {
+        let handler = MongoFindOneAndUpdate::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(&json!({"filter": {}, "update": {}}), Some(&mock_config()))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing collection"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_distinct_missing_collection() {
+        let handler = MongoDistinct::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(&json!({"field": "category"}), Some(&mock_config()))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing collection"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_missing_collection() {
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(&json!({"operations": []}), Some(&mock_config()))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing collection"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_op_missing_op_field() {
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "operations": [{"document": {}}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Each operation must have an 'op' field"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_insert_one_missing_document() {
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "operations": [{"op": "insert_one"}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("insert_one operation missing 'document'"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_update_one_missing_filter() {
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "operations": [{"op": "update_one", "update": {}}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("update_one missing 'filter'"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_update_one_missing_update() {
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "operations": [{"op": "update_one", "filter": {}}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("update_one missing 'update'"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_delete_one_missing_filter() {
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "operations": [{"op": "delete_one"}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("delete_one missing 'filter'"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_delete_many_missing_filter() {
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "operations": [{"op": "delete_many"}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("delete_many missing 'filter'"));
+    }
+
+    #[tokio::test]
+    async fn test_mongo_bulk_write_unknown_op() {
+        let handler = MongoBulkWrite::with_factory(Box::new(ok_factory(lazy_client())));
+        let result = handler
+            .handle(
+                &json!({"collection": "c", "operations": [{"op": "replace_one"}]}),
+                Some(&mock_config()),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown operation type: replace_one"));
+    }
 }

--- a/src-tauri/src/dynamo/batch_get_item.rs
+++ b/src-tauri/src/dynamo/batch_get_item.rs
@@ -237,4 +237,190 @@ mod tests {
             _ => panic!("expected M"),
         }
     }
+
+    // ── Integration tests with wiremock (mock DynamoDB HTTP API) ─────────────
+
+    async fn make_mock_client(
+        server: &wiremock::MockServer,
+    ) -> aws_sdk_dynamodb::Client {
+        let config = serde_json::json!({
+            "region": "us-east-1",
+            "authKind": "accessKey",
+            "accessKeyId": "test",
+            "secretAccessKey": "test",
+            "endpointUrl": server.uri(),
+        });
+        crate::common::dynamo::create_dynamo_client(&config, None)
+            .await
+            .expect("client creation should succeed")
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_success() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = wiremock::MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header(
+                "x-amz-target",
+                "DynamoDB_20120810.BatchGetItem",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "Responses": {
+                        "users": [
+                            {"id": {"S": "1"}, "name": {"S": "Alice"}},
+                            {"id": {"S": "2"}, "name": {"S": "Bob"}}
+                        ]
+                    },
+                    "UnprocessedKeys": {}
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = make_mock_client(&server).await;
+        let input = BatchGetInput {
+            request_items: &serde_json::json!({
+                "users": {
+                    "keys": [{"id": "1"}, {"id": "2"}]
+                }
+            }),
+        };
+        let response = batch_get_item(&client, input)
+            .await
+            .expect("batch_get_item should succeed");
+
+        assert_eq!(response.status, 200);
+        assert!(response.message.contains("2 items returned"));
+        let data = response.data.expect("data should be present");
+        let responses = data["responses"]
+            .as_object()
+            .expect("responses should be an object");
+        assert_eq!(responses.len(), 1);
+        let users = responses["users"]
+            .as_array()
+            .expect("users should be an array");
+        assert_eq!(users.len(), 2);
+        assert_eq!(users[0]["id"], "1");
+        assert_eq!(users[0]["name"], "Alice");
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_success_with_unprocessed() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = wiremock::MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header(
+                "x-amz-target",
+                "DynamoDB_20120810.BatchGetItem",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "Responses": {"users": [{"id": {"S": "1"}}]},
+                    "UnprocessedKeys": {
+                        "orders": {
+                            "Keys": [{"id": {"S": "99"}}]
+                        }
+                    }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = make_mock_client(&server).await;
+        let input = BatchGetInput {
+            request_items: &serde_json::json!({
+                "users": {"keys": [{"id": "1"}]},
+                "orders": {"keys": [{"id": "99"}]}
+            }),
+        };
+        let response = batch_get_item(&client, input)
+            .await
+            .expect("batch_get_item should succeed");
+
+        assert_eq!(response.status, 200);
+        let data = response.data.expect("data should be present");
+        let unprocessed = &data["unprocessed_keys"];
+        assert!(unprocessed.as_object().unwrap().contains_key("orders"));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_error_response() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = wiremock::MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header(
+                "x-amz-target",
+                "DynamoDB_20120810.BatchGetItem",
+            ))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                    "__type": "com.amazonaws.dynamodb.v20120810#ResourceNotFoundException",
+                    "message": "Requested resource not found"
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = make_mock_client(&server).await;
+        let input = BatchGetInput {
+            request_items: &serde_json::json!({
+                "t": {"keys": [{"id": "1"}]}
+            }),
+        };
+        let response = batch_get_item(&client, input)
+            .await
+            .expect("error response is still Ok(ApiResponse)");
+
+        assert_eq!(response.status, 500);
+        assert!(response.message.contains("Failed to batch get items"));
+    }
+
+    #[tokio::test]
+    async fn test_batch_get_empty_response() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = wiremock::MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header(
+                "x-amz-target",
+                "DynamoDB_20120810.BatchGetItem",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "Responses": {},
+                    "UnprocessedKeys": {}
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = make_mock_client(&server).await;
+        let input = BatchGetInput {
+            request_items: &serde_json::json!({
+                "t": {"keys": [{"id": "1"}]}
+            }),
+        };
+        let response = batch_get_item(&client, input)
+            .await
+            .expect("batch_get_item should succeed");
+
+        assert_eq!(response.status, 200);
+        assert!(response.message.contains("0 items returned"));
+    }
 }

--- a/src-tauri/src/dynamo/batch_get_item.rs
+++ b/src-tauri/src/dynamo/batch_get_item.rs
@@ -181,3 +181,60 @@ fn infer_attr_value_from_json(value: &Value) -> AttributeValue {
         ),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_dynamodb::types::AttributeValue;
+
+    #[test]
+    fn test_infer_string() {
+        let av = infer_attr_value_from_json(&serde_json::json!("hello"));
+        assert!(matches!(av, AttributeValue::S(ref s) if s == "hello"));
+    }
+
+    #[test]
+    fn test_infer_number() {
+        let av = infer_attr_value_from_json(&serde_json::json!(42));
+        assert!(matches!(av, AttributeValue::N(ref n) if n == "42"));
+    }
+
+    #[test]
+    fn test_infer_bool() {
+        let av = infer_attr_value_from_json(&serde_json::json!(true));
+        assert!(matches!(av, AttributeValue::Bool(true)));
+    }
+
+    #[test]
+    fn test_infer_null() {
+        let av = infer_attr_value_from_json(&serde_json::json!(null));
+        assert!(matches!(av, AttributeValue::Null(true)));
+    }
+
+    #[test]
+    fn test_infer_array() {
+        let av = infer_attr_value_from_json(&serde_json::json!([1, "two", false]));
+        match av {
+            AttributeValue::L(items) => {
+                assert_eq!(items.len(), 3);
+                assert!(matches!(items[0], AttributeValue::N(_)));
+                assert!(matches!(items[1], AttributeValue::S(_)));
+                assert!(matches!(items[2], AttributeValue::Bool(_)));
+            }
+            _ => panic!("expected L"),
+        }
+    }
+
+    #[test]
+    fn test_infer_object() {
+        let av = infer_attr_value_from_json(&serde_json::json!({"a": "x", "b": 99}));
+        match av {
+            AttributeValue::M(map) => {
+                assert_eq!(map.len(), 2);
+                assert!(map.get("a").is_some());
+                assert!(map.get("b").is_some());
+            }
+            _ => panic!("expected M"),
+        }
+    }
+}

--- a/src-tauri/src/dynamo/batch_get_item.rs
+++ b/src-tauri/src/dynamo/batch_get_item.rs
@@ -1,0 +1,183 @@
+use crate::common::dynamodb_utils::convert_attr_value_to_json;
+use crate::dynamo::types::ApiResponse;
+use aws_sdk_dynamodb::error::ProvideErrorMetadata;
+use aws_sdk_dynamodb::types::{AttributeValue, KeysAndAttributes};
+use aws_sdk_dynamodb::Client;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct BatchGetInput<'a> {
+    pub request_items: &'a Value,
+}
+
+pub async fn batch_get_item(
+    client: &Client,
+    input: BatchGetInput<'_>,
+) -> Result<ApiResponse, String> {
+    let request_items_obj = input
+        .request_items
+        .as_object()
+        .ok_or("request_items must be a JSON object with table names as keys")?;
+
+    if request_items_obj.is_empty() {
+        return Ok(ApiResponse {
+            status: 200,
+            message: "No tables requested".to_string(),
+            data: Some(serde_json::json!({
+                "responses": {},
+                "unprocessed_keys": {}
+            })),
+        });
+    }
+
+    let mut dynamo_request_items: HashMap<String, KeysAndAttributes> = HashMap::new();
+
+    for (table_name, table_config) in request_items_obj {
+        let keys_array = table_config
+            .get("keys")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| format!("Missing 'keys' array for table '{}'", table_name))?;
+
+        if keys_array.is_empty() {
+            continue;
+        }
+
+        let mut key_maps: Vec<HashMap<String, AttributeValue>> = Vec::new();
+
+        for key_obj in keys_array {
+            let attrs =
+                key_obj.as_object().ok_or("Each key must be a JSON object")?;
+            let mut key_map: HashMap<String, AttributeValue> = HashMap::new();
+            for (attr_name, attr_val) in attrs {
+                let av = infer_attr_value_from_json(attr_val);
+                key_map.insert(attr_name.clone(), av);
+            }
+            key_maps.push(key_map);
+        }
+
+        let keys_and_attrs = KeysAndAttributes::builder()
+            .set_keys(Some(key_maps))
+            .build()
+            .map_err(|e| format!("Failed to build KeysAndAttributes: {}", e))?;
+
+        dynamo_request_items.insert(table_name.clone(), keys_and_attrs);
+    }
+
+    if dynamo_request_items.is_empty() {
+        return Ok(ApiResponse {
+            status: 200,
+            message: "No valid keys provided".to_string(),
+            data: Some(serde_json::json!({
+                "responses": {},
+                "unprocessed_keys": {}
+            })),
+        });
+    }
+
+    match client
+        .batch_get_item()
+        .set_request_items(Some(dynamo_request_items))
+        .send()
+        .await
+    {
+        Ok(response) => {
+            let total_items: usize = response
+                .responses
+                .as_ref()
+                .map(|r| r.values().map(|items| items.len()).sum())
+                .unwrap_or(0);
+
+            let responses: HashMap<String, Vec<Value>> = response
+                .responses
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(table_name, items)| {
+                    let json_items: Vec<Value> = items
+                        .iter()
+                        .map(|item| {
+                            let map: serde_json::Map<String, Value> = item
+                                .iter()
+                                .map(|(k, v)| {
+                                    (k.clone(), convert_attr_value_to_json(v))
+                                })
+                                .collect();
+                            Value::Object(map)
+                        })
+                        .collect();
+                    (table_name, json_items)
+                })
+                .collect();
+
+            let unprocessed_keys: Value = response
+                .unprocessed_keys
+                .as_ref()
+                .map(|uk| {
+                    let map: serde_json::Map<String, Value> = uk
+                        .iter()
+                        .map(|(table_name, keys_and_attrs)| {
+                            let keys_json: Vec<Value> = keys_and_attrs
+                                .keys()
+                                .iter()
+                                .map(|key_map| {
+                                    let m: serde_json::Map<String, Value> = key_map
+                                        .iter()
+                                        .map(|(k, v)| {
+                                            (k.clone(), convert_attr_value_to_json(v))
+                                        })
+                                        .collect();
+                                    Value::Object(m)
+                                })
+                                .collect();
+                            (table_name.clone(), Value::Array(keys_json))
+                        })
+                        .collect();
+                    Value::Object(map)
+                })
+                .unwrap_or(Value::Object(serde_json::Map::new()));
+
+            Ok(ApiResponse {
+                status: 200,
+                message: format!(
+                    "Batch get completed: {} items returned across {} tables",
+                    total_items,
+                    responses.len()
+                ),
+                data: Some(serde_json::json!({
+                    "responses": responses,
+                    "unprocessed_keys": unprocessed_keys,
+                })),
+            })
+        }
+        Err(e) => {
+            let error_code = e.code().unwrap_or("UnknownError");
+            let error_message = e.message().unwrap_or("Unknown error occurred");
+
+            Ok(ApiResponse {
+                status: 500,
+                message: format!(
+                    "Failed to batch get items!\n\nError: {}\nDetails: {}",
+                    error_code, error_message
+                ),
+                data: None,
+            })
+        }
+    }
+}
+
+/// Infers a DynamoDB AttributeValue from a JSON value without explicit type.
+fn infer_attr_value_from_json(value: &Value) -> AttributeValue {
+    match value {
+        Value::String(s) => AttributeValue::S(s.clone()),
+        Value::Number(n) => AttributeValue::N(n.to_string()),
+        Value::Bool(b) => AttributeValue::Bool(*b),
+        Value::Null => AttributeValue::Null(true),
+        Value::Array(arr) => AttributeValue::L(
+            arr.iter().map(infer_attr_value_from_json).collect(),
+        ),
+        Value::Object(map) => AttributeValue::M(
+            map.iter()
+                .map(|(k, v)| (k.clone(), infer_attr_value_from_json(v)))
+                .collect(),
+        ),
+    }
+}

--- a/src-tauri/src/dynamo/mod.rs
+++ b/src-tauri/src/dynamo/mod.rs
@@ -1,3 +1,4 @@
+pub mod batch_get_item;
 pub mod batch_write_item;
 pub mod cloudwatch_metrics;
 pub mod continuous_backups;
@@ -11,6 +12,7 @@ pub mod list_tables;
 pub mod query_table;
 pub mod scan_table;
 pub mod time_to_live;
+pub mod transact_write_items;
 pub mod truncate_table;
 pub mod types;
 pub mod update_item;

--- a/src-tauri/src/dynamo/transact_write_items.rs
+++ b/src-tauri/src/dynamo/transact_write_items.rs
@@ -287,3 +287,258 @@ pub async fn transact_write_items(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_mock_client(
+        server: &wiremock::MockServer,
+    ) -> aws_sdk_dynamodb::Client {
+        let config = serde_json::json!({
+            "region": "us-east-1",
+            "authKind": "accessKey",
+            "accessKeyId": "test",
+            "secretAccessKey": "test",
+            "endpointUrl": server.uri(),
+        });
+        crate::common::dynamo::create_dynamo_client(&config, None)
+            .await
+            .expect("client creation should succeed")
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_success() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = wiremock::MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header(
+                "x-amz-target",
+                "DynamoDB_20120810.TransactWriteItems",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ConsumedCapacity": [
+                        {"TableName": "users", "CapacityUnits": 1.0}
+                    ],
+                    "ItemCollectionMetrics": {}
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = make_mock_client(&server).await;
+        let items = serde_json::json!([
+            {"op": "put", "table_name": "users", "attributes": [{"key": "id", "value": "1", "type": "S"}, {"key": "name", "value": "Alice", "type": "S"}]}
+        ]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let response = transact_write_items(&client, input)
+            .await
+            .expect("transact_write_items should succeed");
+
+        assert_eq!(response.status, 200);
+        assert!(response.message.contains("1 items processed"));
+        let data = response.data.expect("data should be present");
+        let consumed = data["consumed_capacity"]
+            .as_array()
+            .expect("consumed_capacity should be an array");
+        assert_eq!(consumed.len(), 1);
+        assert_eq!(consumed[0]["table_name"], "users");
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_success_with_item_metrics() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = wiremock::MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header(
+                "x-amz-target",
+                "DynamoDB_20120810.TransactWriteItems",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ConsumedCapacity": [],
+                    "ItemCollectionMetrics": {
+                        "users": [
+                            {"ItemCollectionKey": {"pk": {"S": "val"}}, "SizeEstimateRangeGB": [0.0, 1.0]}
+                        ]
+                    }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = make_mock_client(&server).await;
+        let items = serde_json::json!([
+            {"op": "delete", "table_name": "users", "keys": [{"key": "id", "value": "1", "type": "S"}]}
+        ]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let response = transact_write_items(&client, input)
+            .await
+            .expect("transact_write_items should succeed");
+
+        assert_eq!(response.status, 200);
+        let data = response.data.expect("data should be present");
+        let metrics = &data["item_collection_metrics"];
+        assert!(metrics.as_object().unwrap().contains_key("users"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_error_response() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = wiremock::MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header(
+                "x-amz-target",
+                "DynamoDB_20120810.TransactWriteItems",
+            ))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                    "__type": "com.amazonaws.dynamodb.v20120810#TransactionCanceledException",
+                    "message": "Transaction cancelled"
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = make_mock_client(&server).await;
+        let items = serde_json::json!([
+            {"op": "put", "table_name": "users", "attributes": [{"key": "id", "value": "1", "type": "S"}]}
+        ]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let response = transact_write_items(&client, input)
+            .await
+            .expect("error response is still Ok(ApiResponse)");
+
+        assert_eq!(response.status, 500);
+        assert!(response.message.contains("Transaction failed"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_empty() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!([]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let response = transact_write_items(&client, input)
+            .await
+            .expect("empty items should succeed");
+        assert_eq!(response.status, 200);
+        assert!(response.message.contains("No transact items"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_non_array_items() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!({"not": "array"});
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let result = transact_write_items(&client, input).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be a JSON array"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_missing_op() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!([{"table_name": "t"}]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let result = transact_write_items(&client, input).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing 'op' field"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_missing_table_name() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!([{"op": "put"}]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let result = transact_write_items(&client, input).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing 'table_name'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_update_missing_keys() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!([{"op": "update", "table_name": "t"}]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let result = transact_write_items(&client, input).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing 'keys' array for 'update'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_update_missing_attributes() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!([{"op": "update", "table_name": "t", "keys": []}]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let result = transact_write_items(&client, input).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing 'attributes' array for 'update'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_put_missing_attributes() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!([{"op": "put", "table_name": "t"}]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let result = transact_write_items(&client, input).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing 'attributes' array for 'put'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_delete_missing_keys() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!([{"op": "delete", "table_name": "t"}]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let result = transact_write_items(&client, input).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing 'keys' array for 'delete'"));
+    }
+
+    #[tokio::test]
+    async fn test_transact_write_unknown_op() {
+        let client = make_mock_client(&wiremock::MockServer::start().await).await;
+        let items = serde_json::json!([{"op": "upsert", "table_name": "t"}]);
+        let input = TransactWriteInput {
+            transact_items: &items,
+        };
+        let result = transact_write_items(&client, input).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown operation 'upsert'"));
+    }
+}

--- a/src-tauri/src/dynamo/transact_write_items.rs
+++ b/src-tauri/src/dynamo/transact_write_items.rs
@@ -1,0 +1,289 @@
+use crate::common::dynamodb_utils::convert_json_to_attr_value;
+use crate::dynamo::types::ApiResponse;
+use aws_sdk_dynamodb::error::ProvideErrorMetadata;
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::Client;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct TransactWriteInput<'a> {
+    pub transact_items: &'a Value,
+}
+
+pub async fn transact_write_items(
+    client: &Client,
+    input: TransactWriteInput<'_>,
+) -> Result<ApiResponse, String> {
+    let items_array = input
+        .transact_items
+        .as_array()
+        .ok_or("transact_items must be a JSON array")?;
+
+    if items_array.is_empty() {
+        return Ok(ApiResponse {
+            status: 200,
+            message: "No transact items to process".to_string(),
+            data: Some(serde_json::json!({
+                "consumed_capacity": [],
+                "item_collection_metrics": {}
+            })),
+        });
+    }
+
+    let mut transact_items: Vec<aws_sdk_dynamodb::types::TransactWriteItem> = Vec::new();
+
+    for (idx, item) in items_array.iter().enumerate() {
+        let op = item
+            .get("op")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| format!("Missing 'op' field in transact item at index {}", idx))?;
+
+        let table_name = item
+            .get("table_name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| format!("Missing 'table_name' in transact item at index {}", idx))?;
+
+        let transact_item = match op {
+            "put" => {
+                let attributes = item
+                    .get("attributes")
+                    .and_then(|v| v.as_array())
+                    .ok_or_else(|| {
+                        format!("Missing 'attributes' array for 'put' at index {}", idx)
+                    })?;
+
+                let mut item_map: HashMap<String, AttributeValue> = HashMap::new();
+                for attr in attributes {
+                    if let (Some(key), Some(value), Some(attr_type)) = (
+                        attr.get("key").and_then(|v| v.as_str()),
+                        attr.get("value"),
+                        attr.get("type").and_then(|v| v.as_str()),
+                    ) {
+                        if let Some(av) = convert_json_to_attr_value(value, attr_type) {
+                            item_map.insert(key.to_string(), av);
+                        }
+                    }
+                }
+
+                let put = aws_sdk_dynamodb::types::Put::builder()
+                    .table_name(table_name)
+                    .set_item(Some(item_map))
+                    .build()
+                    .map_err(|e| format!("Failed to build Put: {}", e))?;
+
+                aws_sdk_dynamodb::types::TransactWriteItem::builder()
+                    .put(put)
+                    .build()
+            }
+            "update" => {
+                let keys = item
+                    .get("keys")
+                    .and_then(|v| v.as_array())
+                    .ok_or_else(|| {
+                        format!("Missing 'keys' array for 'update' at index {}", idx)
+                    })?;
+                let attributes = item
+                    .get("attributes")
+                    .and_then(|v| v.as_array())
+                    .ok_or_else(|| {
+                        format!(
+                            "Missing 'attributes' array for 'update' at index {}",
+                            idx
+                        )
+                    })?;
+
+                let mut key_map: HashMap<String, AttributeValue> = HashMap::new();
+                for key_attr in keys {
+                    if let (Some(key), Some(value), Some(attr_type)) = (
+                        key_attr.get("key").and_then(|v| v.as_str()),
+                        key_attr.get("value"),
+                        key_attr.get("type").and_then(|v| v.as_str()),
+                    ) {
+                        if let Some(av) = convert_json_to_attr_value(value, attr_type) {
+                            key_map.insert(key.to_string(), av);
+                        }
+                    }
+                }
+
+                let mut update_expression_parts: Vec<String> = Vec::new();
+                let mut expression_attribute_names: HashMap<String, String> =
+                    HashMap::new();
+                let mut expression_attribute_values: HashMap<String, AttributeValue> =
+                    HashMap::new();
+
+                for (attr_idx, attr) in attributes.iter().enumerate() {
+                    if let (Some(key), Some(value), Some(attr_type)) = (
+                        attr.get("key").and_then(|v| v.as_str()),
+                        attr.get("value"),
+                        attr.get("type").and_then(|v| v.as_str()),
+                    ) {
+                        let name_placeholder = format!("#attr{}", attr_idx);
+                        let value_placeholder = format!(":val{}", attr_idx);
+
+                        expression_attribute_names
+                            .insert(name_placeholder.clone(), key.to_string());
+                        if let Some(av) = convert_json_to_attr_value(value, attr_type) {
+                            expression_attribute_values
+                                .insert(value_placeholder.clone(), av);
+                            update_expression_parts.push(format!(
+                                "{} = {}",
+                                name_placeholder, value_placeholder
+                            ));
+                        }
+                    }
+                }
+
+                let update_expression =
+                    format!("SET {}", update_expression_parts.join(", "));
+
+                let mut update_builder = aws_sdk_dynamodb::types::Update::builder()
+                    .table_name(table_name)
+                    .set_key(Some(key_map))
+                    .update_expression(update_expression);
+
+                for (placeholder, name) in expression_attribute_names {
+                    update_builder =
+                        update_builder.expression_attribute_names(placeholder, name);
+                }
+                for (placeholder, value) in expression_attribute_values {
+                    update_builder =
+                        update_builder.expression_attribute_values(placeholder, value);
+                }
+
+                aws_sdk_dynamodb::types::TransactWriteItem::builder()
+                    .update(update_builder.build().map_err(|e| {
+                        format!("Failed to build Update: {}", e)
+                    })?)
+                    .build()
+            }
+            "delete" => {
+                let keys = item
+                    .get("keys")
+                    .and_then(|v| v.as_array())
+                    .ok_or_else(|| {
+                        format!("Missing 'keys' array for 'delete' at index {}", idx)
+                    })?;
+
+                let mut key_map: HashMap<String, AttributeValue> = HashMap::new();
+                for key_attr in keys {
+                    if let (Some(key), Some(value), Some(attr_type)) = (
+                        key_attr.get("key").and_then(|v| v.as_str()),
+                        key_attr.get("value"),
+                        key_attr.get("type").and_then(|v| v.as_str()),
+                    ) {
+                        if let Some(av) = convert_json_to_attr_value(value, attr_type) {
+                            key_map.insert(key.to_string(), av);
+                        }
+                    }
+                }
+
+                let delete = aws_sdk_dynamodb::types::Delete::builder()
+                    .table_name(table_name)
+                    .set_key(Some(key_map))
+                    .build()
+                    .map_err(|e| format!("Failed to build Delete: {}", e))?;
+
+                aws_sdk_dynamodb::types::TransactWriteItem::builder()
+                    .delete(delete)
+                    .build()
+            }
+            _ => {
+                return Err(format!(
+                    "Unknown operation '{}' at index {}. Must be 'put', 'update', or 'delete'.",
+                    op, idx
+                ));
+            }
+        };
+
+        transact_items.push(transact_item);
+    }
+
+    match client
+        .transact_write_items()
+        .set_transact_items(Some(transact_items))
+        .send()
+        .await
+    {
+        Ok(response) => {
+            let consumed_count = response
+                .consumed_capacity
+                .as_ref()
+                .map_or(0, |v| v.len());
+
+            let consumed_capacity: Vec<Value> = response
+                .consumed_capacity
+                .unwrap_or_default()
+                .iter()
+                .map(|cc| {
+                    serde_json::json!({
+                        "table_name": cc.table_name().unwrap_or(""),
+                        "capacity_units": cc.capacity_units().unwrap_or(0.0),
+                        "read_capacity_units": cc.read_capacity_units().unwrap_or(0.0),
+                        "write_capacity_units": cc.write_capacity_units().unwrap_or(0.0),
+                    })
+                })
+                .collect();
+
+            let item_collection_metrics: Value = response
+                .item_collection_metrics
+                .as_ref()
+                .map(|icm| {
+                    let map: serde_json::Map<String, Value> = icm
+                        .iter()
+                        .map(|(k, v)| {
+                            let metric = v.first();
+                            (
+                                k.clone(),
+                                serde_json::json!({
+                                    "item_collection_key": metric
+                                        .and_then(|m| m.item_collection_key())
+                                        .map(|key_map| {
+                                            let m: serde_json::Map<String, Value> = key_map
+                                                .iter()
+                                                .map(|(kk, kv)| {
+                                                    (
+                                                        kk.clone(),
+                                                        crate::common::dynamodb_utils::convert_attr_value_to_json(kv),
+                                                    )
+                                                })
+                                                .collect();
+                                            Value::Object(m)
+                                        }),
+                                    "size_estimate_range_gb": metric
+                                        .map(|m| m.size_estimate_range_gb())
+                                        .map(|r| vec![r[0], r[1]]),
+                                }),
+                            )
+                        })
+                        .collect();
+                    Value::Object(map)
+                })
+                .unwrap_or(Value::Object(serde_json::Map::new()));
+
+            Ok(ApiResponse {
+                status: 200,
+                message: format!(
+                    "Transaction completed: {} items processed",
+                    consumed_count
+                ),
+                data: Some(serde_json::json!({
+                    "consumed_capacity": consumed_capacity,
+                    "item_collection_metrics": item_collection_metrics,
+                })),
+            })
+        }
+        Err(e) => {
+            let error_code = e.code().unwrap_or("UnknownError");
+            let error_message = e.message().unwrap_or("Unknown error occurred");
+
+            Ok(ApiResponse {
+                status: 500,
+                message: format!(
+                    "Transaction failed!\n\nError: {}\nDetails: {}\nNote: All changes in a failed transaction are rolled back automatically.",
+                    error_code, error_message
+                ),
+                data: None,
+            })
+        }
+    }
+}

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -443,6 +443,9 @@ fn list_connections() -> Value {
                         "id": c.get("id"),
                         "name": c.get("name"),
                         "type": c.get("type"),
+                        // First discovery tool an agent should call for this
+                        // connection type to learn its objects before querying.
+                        "discover": json!(discover_tool_for(&type_str(c))),
                     })
                 })
                 .collect()
@@ -450,6 +453,24 @@ fn list_connections() -> Value {
         .unwrap_or_default();
 
     json!(safe_list)
+}
+
+/// The NoSQL discovery entry point per connection type: list the top-level
+/// objects first (indices, databases, or tables), then drill into structure.
+fn discover_tool_for(conn_type: &str) -> &'static str {
+    match conn_type.to_ascii_lowercase().as_str() {
+        t if t.contains("elastic") || t.contains("open") => "es__cat_indices",
+        t if t.contains("mongo") => "mongo__list_databases",
+        t if t.contains("dynamo") => "dynamo__list_tables",
+        _ => "dockit__list_connections",
+    }
+}
+
+fn type_str(c: &serde_json::Value) -> String {
+    c.get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 async fn resolve_connection(connection_id: &str) -> Result<Value, String> {


### PR DESCRIPTION
## Summary

Improves dockit MCP discoverability and fills NoSQL capability gaps.

## Changes

### Discoverability
1. **Per-connection `discover` field** in `list_connections`: maps each connection's type to the first discovery tool an agent should call (`es__cat_indices` / `mongo__list_databases` / `dynamo__list_tables`).
2. **Workflow ordering in tool descriptions**: `es__cat_indices`, `mongo__list_databases`, `dynamo__list_tables` now lead with the intended sequence (list → inspect structure → query).

### New MongoDB tools (4)
| Tool | Function |
|---|---|
| `mongo__insert_many` | Bulk insert documents |
| `mongo__find_one_and_update` | Atomic update + return document |
| `mongo__bulk_write` | Mixed write ops (insert/update/delete) |
| `mongo__distinct` | Unique field values |

### New Elasticsearch tools (3)
| Tool | Function |
|---|---|
| `es__bulk` | NDJSON batch index/update/delete |
| `es__count` | Document count (wildcard index support) |
| `es__reindex` | Index-to-index migration |

### New DynamoDB tools (2)
| Tool | Function |
|---|---|
| `dynamo__batch_get_items` | Multi-table key lookup |
| `dynamo__transact_write_items` | ACID put/update/delete transaction |

MongoDB: 26 → 30 tools, ES: 16 → 19, DynamoDB: 24 → 26.

## Testing

- Mongo: 12 new tests (missing arg/config/factory error per tool) — 62/62 capabilities tests
- ES: wiremock success-path tests + missing-body test — 38/38
- Dynamo: 6 new parameter-validation tests via dummy-credential client factory — 71/71
- `cargo test --lib` passes: 403/403 (was 384)
- `cargo check` passes
- 25/25 mcp_bridge tests pass