### PR TITLE
feat: three-layer user-configurable system prompt (closes #488)

### DIFF
--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -423,6 +423,16 @@ fn to_metadata(cap: &Capability) -> Value {
     })
 }
 
+fn to_safe_connection_summary(connection: &Value) -> Value {
+    json!({
+        "id": connection.get("id"),
+        "name": connection.get("name"),
+        "type": connection.get("type"),
+        // Credentials (password, apiKey, auth) must stay out of this whitelist.
+        "prompt": connection.get("prompt").and_then(Value::as_str),
+    })
+}
+
 fn list_connections() -> Value {
     let handle = match crate::APP_HANDLE.get() {
         Some(h) => h,
@@ -436,17 +446,7 @@ fn list_connections() -> Value {
     let connections = store.get("connections").unwrap_or(json!([]));
     let safe_list: Vec<Value> = connections
         .as_array()
-        .map(|arr| {
-            arr.iter()
-                .map(|c| {
-                    json!({
-                        "id": c.get("id"),
-                        "name": c.get("name"),
-                        "type": c.get("type"),
-                    })
-                })
-                .collect()
-        })
+        .map(|arr| arr.iter().map(to_safe_connection_summary).collect())
         .unwrap_or_default();
 
     json!(safe_list)
@@ -782,6 +782,40 @@ mod tests {
     #[test]
     fn test_list_connections_empty_without_app_handle() {
         assert_eq!(list_connections(), json!([]));
+    }
+
+    #[test]
+    fn test_to_safe_connection_summary_exposes_prompt_only() {
+        let conn = json!({
+            "id": 42,
+            "name": "prod-cluster",
+            "type": "ELASTICSEARCH",
+            "prompt": "Orders cluster. Field meanings: ...",
+            "password": "super-secret",
+            "apiKey": "sk-abc",
+            "auth": { "uri": "mongodb://user:pass@host" },
+        });
+        let summary = to_safe_connection_summary(&conn);
+        assert_eq!(summary["id"], 42);
+        assert_eq!(summary["name"], "prod-cluster");
+        assert_eq!(summary["type"], "ELASTICSEARCH");
+        assert_eq!(summary["prompt"], "Orders cluster. Field meanings: ...");
+        assert!(summary.get("password").is_none());
+        assert!(summary.get("apiKey").is_none());
+        assert!(summary.get("auth").is_none());
+    }
+
+    #[test]
+    fn test_to_safe_connection_summary_prompt_absent_yields_null() {
+        let conn = json!({
+            "id": 7,
+            "name": "no-prompt",
+            "type": "MONGODB",
+            "password": "secret",
+        });
+        let summary = to_safe_connection_summary(&conn);
+        assert_eq!(summary["prompt"], Value::Null);
+        assert!(summary.get("password").is_none());
     }
 
     #[test]

--- a/src/common/agentPrompt.ts
+++ b/src/common/agentPrompt.ts
@@ -1,0 +1,39 @@
+export type ConnectionPrompt = {
+  alias: string;
+  prompt: string;
+};
+
+export type SystemPromptLayers = {
+  /** L1: developer-defined base prompt (built by buildSystemPrompt). Always first. */
+  base: string;
+  /** L2: user-configured global prompt from chat settings. Optional. */
+  userGlobal?: string;
+  /** L3: per-connection prompts for the attached sources. Optional. */
+  connectionPrompts?: Array<ConnectionPrompt>;
+  /** Sidebar assistant context (database/index/editor content). Always last. */
+  sidebarContext?: string;
+};
+
+const NON_EMPTY_SEPARATOR = '\n\n';
+
+const isNonEmpty = (value: string | undefined | null): value is string => Boolean(value?.trim());
+
+export const assembleSystemPrompt = (layers: SystemPromptLayers): string => {
+  const parts: Array<string> = [layers.base];
+
+  if (isNonEmpty(layers.userGlobal)) {
+    parts.push(layers.userGlobal.trim());
+  }
+
+  const prompts = (layers.connectionPrompts ?? []).filter(p => isNonEmpty(p.prompt));
+  const labeled = prompts.length > 1;
+  for (const { alias, prompt } of prompts) {
+    parts.push(labeled ? `## Connection Context: ${alias}\n\n${prompt.trim()}` : prompt.trim());
+  }
+
+  if (isNonEmpty(layers.sidebarContext)) {
+    parts.push(layers.sidebarContext.trim());
+  }
+
+  return parts.join(NON_EMPTY_SEPARATOR);
+};

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -18,4 +18,5 @@ export const CHAT_RUNTIME_DEFAULTS = {
   maxIterations: 200,
   wallClockBudgetMin: 30,
   tokenBudget: 20_000_000,
+  systemPrompt: '',
 } as const;

--- a/src/composables/useChatAgent.ts
+++ b/src/composables/useChatAgent.ts
@@ -11,6 +11,8 @@ import type {
 import type { AgentToolCall, ConfirmationRule, SessionSource } from '@/store/dataStudioStore';
 import { useDataStudioStore } from '@/store/dataStudioStore';
 import { useAppStore } from '@/store';
+import { useConnectionStore } from '@/store/connectionStore';
+import { assembleSystemPrompt } from '@/common/agentPrompt';
 import {
   agentApi,
   type ToolMetadata,
@@ -294,6 +296,7 @@ export const useChatAgent = (config: UseChatAgentConfig) => {
   const activeSession = config.sessionStore.activeSession;
   const dataStudioStore = useDataStudioStore();
   const appStore = useAppStore();
+  const connectionStore = useConnectionStore();
   const isLoading = computed(
     () =>
       activeSession.value?.status === 'running' ||
@@ -351,7 +354,7 @@ export const useChatAgent = (config: UseChatAgentConfig) => {
       const { provider, model } = await appStore.getFeatureModelConfig(config.feature);
       const schema = session.schema ?? context?.schema;
 
-      let systemPrompt = buildSystemPrompt({
+      const base = buildSystemPrompt({
         schema,
         noConnection,
         sources: promptSources,
@@ -359,9 +362,29 @@ export const useChatAgent = (config: UseChatAgentConfig) => {
         permissionsMode: session.permissionsMode,
       });
 
-      if (config.feature === 'sidebarAssistant' && context) {
-        systemPrompt = buildSidebarContextPrompt(context) + systemPrompt;
-      }
+      const userGlobal = !noConnection ? appStore.chatConfig.systemPrompt : undefined;
+
+      const connectionPrompts = Object.entries(context?.connections ?? {}).flatMap(
+        ([alias, entry]) => {
+          const connection = connectionStore.connections.find(
+            candidate => Number(candidate.id) === Number(entry.connectionId),
+          );
+          const prompt = connection?.prompt?.trim();
+          return prompt ? [{ alias, prompt }] : [];
+        },
+      );
+
+      const sidebarContext =
+        config.feature === 'sidebarAssistant' && context
+          ? buildSidebarContextPrompt(context)
+          : undefined;
+
+      const systemPrompt = assembleSystemPrompt({
+        base,
+        userGlobal,
+        connectionPrompts,
+        sidebarContext,
+      });
 
       const settings: Record<string, unknown> = {
         provider: provider.apiCompatibility,
@@ -371,13 +394,14 @@ export const useChatAgent = (config: UseChatAgentConfig) => {
         baseUrl: provider.baseUrl,
         httpProxy: provider.proxy || undefined,
         proxyMode: provider.proxyMode,
-        systemPrompt,
         // Tools are already filtered by getAvailableTools — no need to clear
         // based on connection state. DocKit tools (dockit__list_connections)
         // are always available regardless of connection.
         tools: runtime.tools ?? [],
         ...appStore.chatConfig,
         contextWindowOverride: provider.contextWindowOverride,
+        // Merged 3-layer prompt wins over the raw per-layer fields spread above
+        systemPrompt,
       };
 
       if (context?.connections) {

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -1003,7 +1003,10 @@ export const enUS = {
 
     prompt: {
       title: 'Agent Prompt',
-      label: 'System Prompt',
+      label: 'Agent Prompt',
+      add: 'Add agent prompt',
+      edit: 'Edit agent prompt',
+      configured: 'Configured',
       description:
         'Connection-specific system prompt. Sent to the LLM whenever this connection is used by the agent, after the global system prompt.',
       placeholder:

--- a/src/lang/enUS.ts
+++ b/src/lang/enUS.ts
@@ -203,6 +203,9 @@ export const enUS = {
         tokenBudgetLabel: 'Token budget',
         tokenBudgetDescription:
           'Maximum cumulative input tokens across all iterations in one agent run. Default: 1,000,000.',
+        systemPromptLabel: 'System Prompt',
+        systemPromptDescription:
+          'Global system prompt sent to the LLM on every chat, before any connection-specific context. Use it to describe your overall usage, terminology, or business context.',
       },
 
       models: {
@@ -997,6 +1000,16 @@ export const enUS = {
 
     connectionTarget: 'Connection Target',
     notFound: 'Connection not found',
+
+    prompt: {
+      title: 'Agent Prompt',
+      label: 'System Prompt',
+      description:
+        'Connection-specific system prompt. Sent to the LLM whenever this connection is used by the agent, after the global system prompt.',
+      placeholder:
+        'Describe this connection for the AI agent, e.g. business meaning of the data, naming conventions, common queries...',
+      clear: 'Clear',
+    },
 
     ssh: {
       title: 'SSH Tunnel',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -194,6 +194,9 @@ export const zhCN = {
         wallClockBudgetDescription: '单次代理运行的最长挂钟时间，超出后代理将优雅停止。默认：30。',
         tokenBudgetLabel: 'Token 预算',
         tokenBudgetDescription: '单次代理运行中所有迭代累计的最大输入 Token 数。默认：1,000,000。',
+        systemPromptLabel: '系统提示词',
+        systemPromptDescription:
+          '每次对话都会发送给 LLM 的全局系统提示词，位于任何连接级上下文之前。可用于描述你的整体用法、术语或业务上下文。',
       },
 
       models: {
@@ -960,6 +963,15 @@ export const zhCN = {
 
     connectionTarget: '连接目标',
     notFound: '未找到连接',
+
+    prompt: {
+      title: 'Agent 提示词',
+      label: '系统提示词',
+      description:
+        '连接专属系统提示词。每当此连接被 agent 使用时，会发送给 LLM，位于全局系统提示词之后。',
+      placeholder: '向 AI agent 描述此连接，例如数据的业务含义、命名约定、常见查询……',
+      clear: '清除',
+    },
 
     ssh: {
       title: 'SSH 隧道',

--- a/src/lang/zhCN.ts
+++ b/src/lang/zhCN.ts
@@ -966,7 +966,10 @@ export const zhCN = {
 
     prompt: {
       title: 'Agent 提示词',
-      label: '系统提示词',
+      label: 'Agent 提示词',
+      add: '添加 Agent 提示词',
+      edit: '编辑 Agent 提示词',
+      configured: '已配置',
       description:
         '连接专属系统提示词。每当此连接被 agent 使用时，会发送给 LLM，位于全局系统提示词之后。',
       placeholder: '向 AI agent 描述此连接，例如数据的业务含义、命名约定、常见查询……',

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -81,6 +81,7 @@ export type ChatRuntimeConfig = {
   maxIterations: number;
   wallClockBudgetMin: number;
   tokenBudget: number;
+  systemPrompt: string;
 };
 
 export type LlmSettings = {
@@ -483,6 +484,7 @@ const mergeLlmSettings = (stored: Partial<LlmSettings> | undefined): LlmSettings
       wallClockBudgetMin:
         stored?.chat?.wallClockBudgetMin ?? CHAT_RUNTIME_DEFAULTS.wallClockBudgetMin,
       tokenBudget: stored?.chat?.tokenBudget ?? CHAT_RUNTIME_DEFAULTS.tokenBudget,
+      systemPrompt: stored?.chat?.systemPrompt ?? CHAT_RUNTIME_DEFAULTS.systemPrompt,
     },
   };
 };
@@ -567,6 +569,7 @@ export const useAppStore = defineStore('app', {
         wallClockBudgetMin:
           state.llmSettings.chat?.wallClockBudgetMin ?? CHAT_RUNTIME_DEFAULTS.wallClockBudgetMin,
         tokenBudget: state.llmSettings.chat?.tokenBudget ?? CHAT_RUNTIME_DEFAULTS.tokenBudget,
+        systemPrompt: state.llmSettings.chat?.systemPrompt ?? CHAT_RUNTIME_DEFAULTS.systemPrompt,
       };
     },
   },

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -218,6 +218,7 @@ export type DynamoDBConnection = {
   tables?: Array<DynamoTableSummary>;
   favoriteTables?: Array<string>;
   sshTunnel?: SshConnectionConfig;
+  prompt?: string;
 };
 
 // Shared base for HTTP-API-compatible search engines
@@ -236,6 +237,7 @@ export type SearchConnectionBase = {
   activeIndex: ElasticSearchIndex | undefined;
   version: string;
   sshTunnel?: SshConnectionConfig;
+  prompt?: string;
   clusterName: string;
   clusterUuid: string;
 };
@@ -301,6 +303,7 @@ export type MongoDBConnection = {
   collections?: MongoDBCollection[];
   favoriteCollections?: Array<{ database: string; collection: string }>;
   sshTunnel?: SshConnectionConfig;
+  prompt?: string;
 };
 
 export type MongoDBCollection = {

--- a/src/views/connect/components/connection-prompt-dialog.vue
+++ b/src/views/connect/components/connection-prompt-dialog.vue
@@ -1,0 +1,110 @@
+<template>
+  <Dialog :open="visible" @update:open="onOpenChange">
+    <DialogContent class="sm:max-w-[560px]" :show-close="false">
+      <DialogHeader>
+        <DialogTitle>{{ $t('connection.prompt.title') }}</DialogTitle>
+        <button
+          class="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none"
+          aria-label="Close"
+          @click="close"
+        >
+          <X class="h-4 w-4" />
+        </button>
+      </DialogHeader>
+
+      <div class="space-y-4">
+        <FormItem :label="$t('connection.prompt.label')">
+          <p class="text-sm text-muted-foreground">{{ $t('connection.prompt.description') }}</p>
+          <textarea
+            class="prompt-textarea"
+            :model-value="draft"
+            :placeholder="$t('connection.prompt.placeholder')"
+            @update:model-value="draft = $event"
+          />
+        </FormItem>
+      </div>
+
+      <DialogFooter class="mt-4 flex justify-between sm:justify-between">
+        <div class="left">
+          <Button variant="outline" :disabled="!draft.trim()" @click="onClear">
+            {{ $t('connection.prompt.clear') }}
+          </Button>
+        </div>
+        <div class="right flex gap-2">
+          <Button variant="outline" @click="close">
+            {{ $t('dialogOps.cancel') }}
+          </Button>
+          <Button @click="onSave">{{ $t('dialogOps.confirm') }}</Button>
+        </div>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { X } from 'lucide-vue-next';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { FormItem } from '@/components/ui/form';
+
+const emit = defineEmits<{
+  save: [value: string];
+}>();
+
+const visible = ref(false);
+const draft = ref('');
+
+function show(value?: string) {
+  draft.value = value ?? '';
+  visible.value = true;
+}
+
+function close() {
+  visible.value = false;
+}
+
+function onOpenChange(open: boolean) {
+  visible.value = open;
+}
+
+function onClear() {
+  draft.value = '';
+}
+
+function onSave() {
+  emit('save', draft.value);
+  close();
+}
+
+defineExpose({ show });
+</script>
+
+<style scoped>
+.prompt-textarea {
+  display: flex;
+  min-height: 200px;
+  max-height: 320px;
+  width: 100%;
+  border-radius: 0.375rem;
+  border: 1px solid hsl(var(--input));
+  background-color: hsl(var(--background));
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  resize: vertical;
+}
+.prompt-textarea:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px hsl(var(--ring));
+}
+.prompt-textarea::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+</style>

--- a/src/views/connect/components/connection-prompt-dialog.vue
+++ b/src/views/connect/components/connection-prompt-dialog.vue
@@ -13,15 +13,13 @@
       </DialogHeader>
 
       <div class="space-y-4">
-        <FormItem :label="$t('connection.prompt.label')">
-          <p class="text-sm text-muted-foreground">{{ $t('connection.prompt.description') }}</p>
-          <textarea
-            class="prompt-textarea"
-            :model-value="draft"
-            :placeholder="$t('connection.prompt.placeholder')"
-            @update:model-value="draft = $event"
-          />
-        </FormItem>
+        <p class="text-sm text-muted-foreground">{{ $t('connection.prompt.description') }}</p>
+        <textarea
+          class="prompt-textarea"
+          :model-value="draft"
+          :placeholder="$t('connection.prompt.placeholder')"
+          @update:model-value="draft = $event"
+        />
       </div>
 
       <DialogFooter class="mt-4 flex justify-between sm:justify-between">
@@ -52,7 +50,6 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { FormItem } from '@/components/ui/form';
 
 const emit = defineEmits<{
   save: [value: string];

--- a/src/views/connect/components/dynamodb-connect-dialog.vue
+++ b/src/views/connect/components/dynamodb-connect-dialog.vue
@@ -540,17 +540,26 @@
                 @create-profile="openSshProfileDialog(null)"
                 @edit-profile="openSshProfileDialog($event)"
               />
-              <button type="button" class="prompt-toggle" @click="openPromptDialog">
-                <span class="text-sm font-medium">{{ $t('connection.prompt.label') }}</span>
-                <span class="prompt-summary" :class="{ 'prompt-summary-empty': !promptValue }">
-                  {{
-                    promptValue
-                      ? $t('connection.prompt.description')
-                      : $t('connection.ssh.notConfigured')
-                  }}
+              <div class="prompt-header-row">
+                <span class="i-carbon-chat-bot h-4 w-4 shrink-0 text-muted-foreground" />
+                <span class="text-sm font-medium whitespace-nowrap">
+                  {{ $t('connection.prompt.label') }}
                 </span>
-                <Pencil class="h-3 w-3 shrink-0" />
-              </button>
+                <span v-if="promptValue" class="prompt-summary" :title="promptValue">
+                  {{ $t('connection.prompt.configured') }}
+                </span>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  type="button"
+                  class="ml-auto h-8 w-8 shrink-0"
+                  :title="promptValue ? $t('connection.prompt.edit') : $t('connection.prompt.add')"
+                  @click="openPromptDialog"
+                >
+                  <Plus v-if="!promptValue" class="h-4 w-4" />
+                  <Pencil v-else class="h-3.5 w-3.5" />
+                </Button>
+              </div>
             </div>
           </div>
         </Form>
@@ -581,7 +590,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { X, Loader2, ChevronRight, Eye, EyeOff } from 'lucide-vue-next';
+import { X, Loader2, ChevronRight, Eye, EyeOff, Plus, Pencil } from 'lucide-vue-next';
 import { cloneDeep, debounce } from 'lodash';
 import { useForm } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/zod';
@@ -1566,31 +1575,21 @@ defineExpose({ showMedal });
   padding-top: 12px;
 }
 
-.prompt-toggle {
+.prompt-header-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  width: 100%;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 8px 0;
-  margin-top: 4px;
-  color: hsl(var(--foreground));
+  gap: 4px;
+  margin-top: 12px;
+  padding-top: 12px;
   border-top: 1px solid hsl(var(--border));
 }
 
 .prompt-summary {
-  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: left;
   font-size: 0.75rem;
   color: hsl(var(--muted-foreground));
-}
-
-.prompt-summary-empty {
-  font-style: italic;
 }
 </style>

--- a/src/views/connect/components/dynamodb-connect-dialog.vue
+++ b/src/views/connect/components/dynamodb-connect-dialog.vue
@@ -54,20 +54,20 @@
               :model-value="connectionMode"
               @update:model-value="value => onConnectionModeChange(value as string)"
             >
-              <TabsList class="w-full">
-                <TabsTrigger class="flex-1" value="accessKey">
+              <TabsList class="w-full h-8">
+                <TabsTrigger class="flex-1 py-0.5" value="accessKey">
                   {{ $t('connection.authAccessKey') }}
                 </TabsTrigger>
-                <TabsTrigger class="flex-1" value="profile">
+                <TabsTrigger class="flex-1 py-0.5" value="profile">
                   {{ $t('connection.authProfile') }}
                 </TabsTrigger>
-                <TabsTrigger class="flex-1" value="sso">
+                <TabsTrigger class="flex-1 py-0.5" value="sso">
                   {{ $t('connection.authSso') }}
                 </TabsTrigger>
-                <TabsTrigger class="flex-1" value="assumeRole">
+                <TabsTrigger class="flex-1 py-0.5" value="assumeRole">
                   {{ $t('connection.authAssumeRole') }}
                 </TabsTrigger>
-                <TabsTrigger class="flex-1" value="local">
+                <TabsTrigger class="flex-1 py-0.5" value="local">
                   {{ $t('connection.localTarget') }}
                 </TabsTrigger>
               </TabsList>

--- a/src/views/connect/components/dynamodb-connect-dialog.vue
+++ b/src/views/connect/components/dynamodb-connect-dialog.vue
@@ -540,6 +540,17 @@
                 @create-profile="openSshProfileDialog(null)"
                 @edit-profile="openSshProfileDialog($event)"
               />
+              <button type="button" class="prompt-toggle" @click="openPromptDialog">
+                <span class="text-sm font-medium">{{ $t('connection.prompt.label') }}</span>
+                <span class="prompt-summary" :class="{ 'prompt-summary-empty': !promptValue }">
+                  {{
+                    promptValue
+                      ? $t('connection.prompt.description')
+                      : $t('connection.ssh.notConfigured')
+                  }}
+                </span>
+                <Pencil class="h-3 w-3 shrink-0" />
+              </button>
             </div>
           </div>
         </Form>
@@ -565,6 +576,7 @@
     </DialogContent>
   </Dialog>
   <SshProfileDialog ref="sshProfileDialogRef" />
+  <ConnectionPromptDialog ref="promptDialogRef" @save="onPromptSave" />
 </template>
 
 <script setup lang="ts">
@@ -592,6 +604,7 @@ import { dynamoApi } from '../../../datasources/dynamoApi';
 import { useFormValidation, useDialogResult } from '@/composables';
 import { SshTunnelSection } from '@/components/ssh';
 import SshProfileDialog from './ssh-profile-dialog.vue';
+import ConnectionPromptDialog from './connection-prompt-dialog.vue';
 
 import {
   Dialog,
@@ -630,7 +643,9 @@ const availableProfiles = ref<string[]>([]);
 const { handleBlur, getError, markSubmitted, resetValidation } = useFormValidation();
 const sshConfig = ref<SshConnectionConfig>({ enabled: false });
 const sshProfileDialogRef = ref<InstanceType<typeof SshProfileDialog> | null>(null);
+const promptDialogRef = ref<InstanceType<typeof ConnectionPromptDialog> | null>(null);
 const showAdvanced = ref(false);
+const promptValue = computed(() => formData.value.prompt ?? '');
 
 function openSshProfileDialog(profileId: string | null) {
   if (sshProfileDialogRef.value) {
@@ -639,6 +654,16 @@ function openSshProfileDialog(profileId: string | null) {
       : null;
     sshProfileDialogRef.value.show(profile);
   }
+}
+
+function openPromptDialog() {
+  if (promptDialogRef.value) {
+    promptDialogRef.value.show(formData.value.prompt);
+  }
+}
+
+function onPromptSave(value: string) {
+  formData.value.prompt = value.trim() || undefined;
 }
 
 const sshRemoteHost = computed(() => {
@@ -1539,5 +1564,33 @@ defineExpose({ showMedal });
 
 .advanced-content {
   padding-top: 12px;
+}
+
+.prompt-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 0;
+  margin-top: 4px;
+  color: hsl(var(--foreground));
+  border-top: 1px solid hsl(var(--border));
+}
+
+.prompt-summary {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.prompt-summary-empty {
+  font-style: italic;
 }
 </style>

--- a/src/views/connect/components/es-connect-dialog.vue
+++ b/src/views/connect/components/es-connect-dialog.vue
@@ -219,17 +219,26 @@
                 @create-profile="openSshProfileDialog(null)"
                 @edit-profile="openSshProfileDialog($event)"
               />
-              <button type="button" class="prompt-toggle" @click="openPromptDialog">
-                <span class="text-sm font-medium">{{ $t('connection.prompt.label') }}</span>
-                <span class="prompt-summary" :class="{ 'prompt-summary-empty': !promptValue }">
-                  {{
-                    promptValue
-                      ? $t('connection.prompt.description')
-                      : $t('connection.ssh.notConfigured')
-                  }}
+              <div class="prompt-header-row">
+                <span class="i-carbon-chat-bot h-4 w-4 shrink-0 text-muted-foreground" />
+                <span class="text-sm font-medium whitespace-nowrap">
+                  {{ $t('connection.prompt.label') }}
                 </span>
-                <Pencil class="h-3 w-3 shrink-0" />
-              </button>
+                <span v-if="promptValue" class="prompt-summary" :title="promptValue">
+                  {{ $t('connection.prompt.configured') }}
+                </span>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  type="button"
+                  class="ml-auto h-8 w-8 shrink-0"
+                  :title="promptValue ? $t('connection.prompt.edit') : $t('connection.prompt.add')"
+                  @click="openPromptDialog"
+                >
+                  <Plus v-if="!promptValue" class="h-4 w-4" />
+                  <Pencil v-else class="h-3.5 w-3.5" />
+                </Button>
+              </div>
             </div>
           </div>
         </Form>
@@ -260,7 +269,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { X, Loader2, ChevronRight, Eye, EyeOff } from 'lucide-vue-next';
+import { X, Loader2, ChevronRight, Eye, EyeOff, Plus, Pencil } from 'lucide-vue-next';
 import { cloneDeep } from 'lodash';
 import { useForm } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/zod';
@@ -641,31 +650,21 @@ defineExpose({ showMedal });
   padding-top: 12px;
 }
 
-.prompt-toggle {
+.prompt-header-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  width: 100%;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 8px 0;
-  margin-top: 4px;
-  color: hsl(var(--foreground));
+  gap: 4px;
+  margin-top: 12px;
+  padding-top: 12px;
   border-top: 1px solid hsl(var(--border));
 }
 
 .prompt-summary {
-  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: left;
   font-size: 0.75rem;
   color: hsl(var(--muted-foreground));
-}
-
-.prompt-summary-empty {
-  font-style: italic;
 }
 </style>

--- a/src/views/connect/components/es-connect-dialog.vue
+++ b/src/views/connect/components/es-connect-dialog.vue
@@ -144,11 +144,11 @@
                     :model-value="authType"
                     @update:model-value="value => onAuthTypeChange(value as string)"
                   >
-                    <TabsList class="w-full">
-                      <TabsTrigger class="flex-1" value="basic">
+                    <TabsList class="w-full h-8">
+                      <TabsTrigger class="flex-1 py-0.5" value="basic">
                         {{ $t('connection.authTypeBasic') }}
                       </TabsTrigger>
-                      <TabsTrigger class="flex-1" value="apiKey">
+                      <TabsTrigger class="flex-1 py-0.5" value="apiKey">
                         {{ $t('connection.authTypeApiKey') }}
                       </TabsTrigger>
                     </TabsList>

--- a/src/views/connect/components/es-connect-dialog.vue
+++ b/src/views/connect/components/es-connect-dialog.vue
@@ -219,6 +219,17 @@
                 @create-profile="openSshProfileDialog(null)"
                 @edit-profile="openSshProfileDialog($event)"
               />
+              <button type="button" class="prompt-toggle" @click="openPromptDialog">
+                <span class="text-sm font-medium">{{ $t('connection.prompt.label') }}</span>
+                <span class="prompt-summary" :class="{ 'prompt-summary-empty': !promptValue }">
+                  {{
+                    promptValue
+                      ? $t('connection.prompt.description')
+                      : $t('connection.ssh.notConfigured')
+                  }}
+                </span>
+                <Pencil class="h-3 w-3 shrink-0" />
+              </button>
             </div>
           </div>
         </Form>
@@ -244,6 +255,7 @@
     </DialogContent>
   </Dialog>
   <SshProfileDialog ref="sshProfileDialogRef" />
+  <ConnectionPromptDialog ref="promptDialogRef" @save="onPromptSave" />
 </template>
 
 <script setup lang="ts">
@@ -264,6 +276,7 @@ import { useLang } from '../../../lang';
 import { useFormValidation, useDialogResult } from '@/composables';
 import { SshTunnelSection } from '@/components/ssh';
 import SshProfileDialog from './ssh-profile-dialog.vue';
+import ConnectionPromptDialog from './connection-prompt-dialog.vue';
 
 import {
   Dialog,
@@ -295,7 +308,9 @@ const authType = ref<'basic' | 'apiKey'>('basic');
 const { handleBlur, getError, markSubmitted, resetValidation } = useFormValidation();
 const sshConfig = ref<SshConnectionConfig>({ enabled: false });
 const sshProfileDialogRef = ref<InstanceType<typeof SshProfileDialog> | null>(null);
+const promptDialogRef = ref<InstanceType<typeof ConnectionPromptDialog> | null>(null);
 const showAdvanced = ref(false);
+const promptValue = computed(() => formData.value.prompt ?? '');
 
 function openSshProfileDialog(profileId: string | null) {
   if (sshProfileDialogRef.value) {
@@ -304,6 +319,16 @@ function openSshProfileDialog(profileId: string | null) {
       : null;
     sshProfileDialogRef.value.show(profile);
   }
+}
+
+function openPromptDialog() {
+  if (promptDialogRef.value) {
+    promptDialogRef.value.show(formData.value.prompt);
+  }
+}
+
+function onPromptSave(value: string) {
+  formData.value.prompt = value.trim() || undefined;
 }
 
 const defaultFormData = {
@@ -614,5 +639,33 @@ defineExpose({ showMedal });
 
 .advanced-content {
   padding-top: 12px;
+}
+
+.prompt-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 0;
+  margin-top: 4px;
+  color: hsl(var(--foreground));
+  border-top: 1px solid hsl(var(--border));
+}
+
+.prompt-summary {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.prompt-summary-empty {
+  font-style: italic;
 }
 </style>

--- a/src/views/connect/components/mongodb-connect-dialog.vue
+++ b/src/views/connect/components/mongodb-connect-dialog.vue
@@ -226,6 +226,17 @@
                     @create-profile="openSshProfileDialog(null)"
                     @edit-profile="openSshProfileDialog($event)"
                   />
+                  <button type="button" class="prompt-toggle" @click="openPromptDialog">
+                    <span class="text-sm font-medium">{{ $t('connection.prompt.label') }}</span>
+                    <span class="prompt-summary" :class="{ 'prompt-summary-empty': !promptValue }">
+                      {{
+                        promptValue
+                          ? $t('connection.prompt.description')
+                          : $t('connection.ssh.notConfigured')
+                      }}
+                    </span>
+                    <Pencil class="h-3 w-3 shrink-0" />
+                  </button>
                   <p v-if="sshTunnelIssue" class="mt-2 text-xs text-destructive">
                     {{ sshTunnelIssue }}
                   </p>
@@ -259,6 +270,7 @@
     </DialogContent>
   </Dialog>
   <SshProfileDialog ref="sshProfileDialogRef" />
+  <ConnectionPromptDialog ref="promptDialogRef" @save="onPromptSave" />
 </template>
 
 <script setup lang="ts">
@@ -277,6 +289,7 @@ import { useLang } from '../../../lang';
 import { useFormValidation, useDialogResult } from '@/composables';
 import { SshTunnelSection } from '@/components/ssh';
 import SshProfileDialog from './ssh-profile-dialog.vue';
+import ConnectionPromptDialog from './connection-prompt-dialog.vue';
 
 import {
   Dialog,
@@ -314,7 +327,9 @@ const authMode = ref<'none' | 'scram' | 'uri'>('none');
 const { handleBlur, getError, markSubmitted, resetValidation } = useFormValidation();
 const sshConfig = ref<SshConnectionConfig>({ enabled: false });
 const sshProfileDialogRef = ref<InstanceType<typeof SshProfileDialog> | null>(null);
+const promptDialogRef = ref<InstanceType<typeof ConnectionPromptDialog> | null>(null);
 const showAdvanced = ref(false);
+const promptValue = computed(() => formData.value.prompt ?? '');
 
 function openSshProfileDialog(profileId: string | null) {
   if (sshProfileDialogRef.value) {
@@ -323,6 +338,16 @@ function openSshProfileDialog(profileId: string | null) {
       : null;
     sshProfileDialogRef.value.show(profile);
   }
+}
+
+function openPromptDialog() {
+  if (promptDialogRef.value) {
+    promptDialogRef.value.show(formData.value.prompt);
+  }
+}
+
+function onPromptSave(value: string) {
+  formData.value.prompt = value.trim() || undefined;
 }
 
 const defaultFormData = {
@@ -755,5 +780,33 @@ defineExpose({ showMedal });
 
 .advanced-content {
   padding-top: 12px;
+}
+
+.prompt-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 0;
+  margin-top: 4px;
+  color: hsl(var(--foreground));
+  border-top: 1px solid hsl(var(--border));
+}
+
+.prompt-summary {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.prompt-summary-empty {
+  font-style: italic;
 }
 </style>

--- a/src/views/connect/components/mongodb-connect-dialog.vue
+++ b/src/views/connect/components/mongodb-connect-dialog.vue
@@ -226,17 +226,28 @@
                     @create-profile="openSshProfileDialog(null)"
                     @edit-profile="openSshProfileDialog($event)"
                   />
-                  <button type="button" class="prompt-toggle" @click="openPromptDialog">
-                    <span class="text-sm font-medium">{{ $t('connection.prompt.label') }}</span>
-                    <span class="prompt-summary" :class="{ 'prompt-summary-empty': !promptValue }">
-                      {{
-                        promptValue
-                          ? $t('connection.prompt.description')
-                          : $t('connection.ssh.notConfigured')
-                      }}
+                  <div class="prompt-header-row">
+                    <span class="i-carbon-chat-bot h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span class="text-sm font-medium whitespace-nowrap">
+                      {{ $t('connection.prompt.label') }}
                     </span>
-                    <Pencil class="h-3 w-3 shrink-0" />
-                  </button>
+                    <span v-if="promptValue" class="prompt-summary" :title="promptValue">
+                      {{ $t('connection.prompt.configured') }}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      type="button"
+                      class="ml-auto h-8 w-8 shrink-0"
+                      :title="
+                        promptValue ? $t('connection.prompt.edit') : $t('connection.prompt.add')
+                      "
+                      @click="openPromptDialog"
+                    >
+                      <Plus v-if="!promptValue" class="h-4 w-4" />
+                      <Pencil v-else class="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
                   <p v-if="sshTunnelIssue" class="mt-2 text-xs text-destructive">
                     {{ sshTunnelIssue }}
                   </p>
@@ -275,7 +286,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { X, Loader2, ChevronRight, Eye, EyeOff } from 'lucide-vue-next';
+import { X, Loader2, ChevronRight, Eye, EyeOff, Plus, Pencil } from 'lucide-vue-next';
 import { cloneDeep } from 'lodash';
 import { useForm } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/zod';
@@ -782,31 +793,21 @@ defineExpose({ showMedal });
   padding-top: 12px;
 }
 
-.prompt-toggle {
+.prompt-header-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  width: 100%;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 8px 0;
-  margin-top: 4px;
-  color: hsl(var(--foreground));
+  gap: 4px;
+  margin-top: 12px;
+  padding-top: 12px;
   border-top: 1px solid hsl(var(--border));
 }
 
 .prompt-summary {
-  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: left;
   font-size: 0.75rem;
   color: hsl(var(--muted-foreground));
-}
-
-.prompt-summary-empty {
-  font-style: italic;
 }
 </style>

--- a/src/views/connect/components/mongodb-connect-dialog.vue
+++ b/src/views/connect/components/mongodb-connect-dialog.vue
@@ -63,14 +63,14 @@
                   :model-value="authMode"
                   @update:model-value="value => onAuthModeChange(value as string)"
                 >
-                  <TabsList class="w-full">
-                    <TabsTrigger class="flex-1" value="none">
+                  <TabsList class="w-full h-8">
+                    <TabsTrigger class="flex-1 py-0.5" value="none">
                       {{ $t('connection.mongodb.authNone') }}
                     </TabsTrigger>
-                    <TabsTrigger class="flex-1" value="uri">
+                    <TabsTrigger class="flex-1 py-0.5" value="uri">
                       {{ $t('connection.mongodb.authUri') }}
                     </TabsTrigger>
-                    <TabsTrigger class="flex-1" value="scram">
+                    <TabsTrigger class="flex-1 py-0.5" value="scram">
                       {{ $t('connection.mongodb.authScram') }}
                     </TabsTrigger>
                   </TabsList>

--- a/src/views/setting/components/aigc.vue
+++ b/src/views/setting/components/aigc.vue
@@ -182,6 +182,23 @@
           @update:model-value="value => setTokenBudget(Number(value))"
         />
       </div>
+
+      <div
+        class="flex flex-col gap-3 rounded-3xl border border-border/70 bg-card/70 px-5 py-4 shadow-sm md:flex-col md:items-stretch"
+      >
+        <div class="min-w-0 space-y-1">
+          <p class="text-base font-semibold">{{ $t('setting.ai.chat.systemPromptLabel') }}</p>
+          <p class="text-sm text-muted-foreground">
+            {{ $t('setting.ai.chat.systemPromptDescription') }}
+          </p>
+        </div>
+        <textarea
+          class="textarea-input mt-2 w-full resize-y"
+          :model-value="systemPrompt"
+          :placeholder="$t('setting.ai.chat.systemPromptLabel')"
+          @update:model-value="setSystemPrompt"
+        />
+      </div>
     </section>
 
     <Dialog :open="providerDialogOpen" @update:open="handleProviderDialogOpenChange">
@@ -432,6 +449,7 @@ const autoCompactEnabled = computed(() => chatConfig.value.autoCompact);
 const maxIterations = computed(() => chatConfig.value.maxIterations);
 const wallClockBudgetMin = computed(() => chatConfig.value.wallClockBudgetMin);
 const tokenBudget = computed(() => chatConfig.value.tokenBudget);
+const systemPrompt = computed(() => chatConfig.value.systemPrompt);
 
 const setAutoCompact = async (value: boolean) => {
   const result = await appStore.saveChatSettings({ autoCompact: value });
@@ -460,6 +478,13 @@ const setTokenBudget = async (value: number) => {
   const result = await appStore.saveChatSettings({
     tokenBudget: Math.max(1_000, Math.floor(value)),
   });
+  if (!result.success) {
+    message.error(`Failed to persist: ${result.error}`, { closable: true, keepAliveOnHover: true });
+  }
+};
+
+const setSystemPrompt = async (value: string) => {
+  const result = await appStore.saveChatSettings({ systemPrompt: value });
   if (!result.success) {
     message.error(`Failed to persist: ${result.error}`, { closable: true, keepAliveOnHover: true });
   }
@@ -957,3 +982,25 @@ const providerBaseUrlPlaceholder = (kind: ProviderKind) => {
   }
 };
 </script>
+
+<style scoped>
+.textarea-input {
+  display: flex;
+  min-height: 120px;
+  width: 100%;
+  border-radius: 0.375rem;
+  border: 1px solid hsl(var(--input));
+  background-color: hsl(var(--background));
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  resize: vertical;
+}
+.textarea-input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px hsl(var(--ring));
+}
+.textarea-input::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+</style>

--- a/tests/common/agentPrompt.test.ts
+++ b/tests/common/agentPrompt.test.ts
@@ -1,0 +1,76 @@
+import { assembleSystemPrompt } from '../../src/common/agentPrompt';
+
+describe('assembleSystemPrompt', () => {
+  const base = 'You are a Data Studio agent embedded in DocKit.';
+
+  it('returns base alone when no user/connection layers are set', () => {
+    expect(assembleSystemPrompt({ base, connectionPrompts: [] })).toBe(base);
+  });
+
+  it('appends the user global prompt after the base', () => {
+    const result = assembleSystemPrompt({
+      base,
+      userGlobal: 'Answer in Chinese.',
+      connectionPrompts: [],
+    });
+    expect(result).toBe(`${base}\n\nAnswer in Chinese.`);
+  });
+
+  it('appends a single connection prompt flat (no alias header) for one source', () => {
+    const result = assembleSystemPrompt({
+      base,
+      connectionPrompts: [{ alias: 'prod', prompt: 'This cluster holds orders data.' }],
+    });
+    expect(result).toBe(`${base}\n\nThis cluster holds orders data.`);
+  });
+
+  it('labels connection prompts with alias headers when multiple sources', () => {
+    const result = assembleSystemPrompt({
+      base,
+      connectionPrompts: [
+        { alias: 'prod', prompt: 'Orders cluster.' },
+        { alias: 'staging', prompt: 'Test cluster.' },
+      ],
+    });
+    expect(result).toBe(
+      [
+        base,
+        '## Connection Context: prod\n\nOrders cluster.',
+        '## Connection Context: staging\n\nTest cluster.',
+      ].join('\n\n'),
+    );
+  });
+
+  it('skips empty layers and does not emit stray separators', () => {
+    const result = assembleSystemPrompt({
+      base,
+      userGlobal: '  ',
+      connectionPrompts: [{ alias: 'prod', prompt: '' }],
+    });
+    expect(result).toBe(base);
+  });
+
+  it('appends sidebar context last, after all prompt layers', () => {
+    const result = assembleSystemPrompt({
+      base,
+      userGlobal: 'Global rules.',
+      connectionPrompts: [{ alias: 'prod', prompt: 'Orders cluster.' }],
+      sidebarContext: 'Context:\ndatabase: Elasticsearch\n',
+    });
+    expect(result).toBe(
+      [base, 'Global rules.', 'Orders cluster.', 'Context:\ndatabase: Elasticsearch'].join('\n\n'),
+    );
+  });
+
+  it('keeps the full merge order: base → global → connection → sidebar', () => {
+    const result = assembleSystemPrompt({
+      base,
+      userGlobal: 'GGG',
+      connectionPrompts: [{ alias: 'a', prompt: 'CCC' }],
+      sidebarContext: 'SSS',
+    });
+    expect(result.indexOf(base)).toBeLessThan(result.indexOf('GGG'));
+    expect(result.indexOf('GGG')).toBeLessThan(result.indexOf('CCC'));
+    expect(result.indexOf('CCC')).toBeLessThan(result.indexOf('SSS'));
+  });
+});


### PR DESCRIPTION
## Summary

Implements issue #488: user-configurable System Prompts in three layers, merged at a single entry point reused by all AI surfaces (Data Studio agent, sidebar chat, MCP).

### The three layers

| Layer | Source | UI |
|---|---|---|
| **L1 Developer** | hardcoded `buildSystemPrompt` (unchanged) | — |
| **L2 User global** | `ChatRuntimeConfig.systemPrompt` | AI settings → Chat section textarea |
| **L3 Per-connection** | `Connection.prompt` | Connect dialog → Advanced → popup editor |

Merge order: `base → user global → connection context (labeled per source) → sidebar context`, implemented by the pure function `assembleSystemPrompt` (`src/common/agentPrompt.ts`) called only in `useChatAgent.runAgentLoop` — the single entry for both Data Studio and sidebar chat.

### MCP

`list_connections` now exposes the connection `prompt` (whitelist via `to_safe_connection_summary`), so external MCP agents get connection context while credentials (password/apiKey/auth) remain excluded.

## Commits

1. `feat(agent)`: merge three-layer system prompts at the agent entry
2. `feat(settings)`: add global system prompt to chat settings
3. `feat(connection)`: add per-connection agent prompt
4. `feat(mcp)`: expose connection prompt via list_connections
5. `i18n`: add system prompt labels

## Verification

- Jest: 1590/1590 pass (incl. new `agentPrompt.test.ts`, 7 tests)
- Rust `cargo test`: 374/374 pass (incl. 2 new whitelist-security tests)
- `tsc --noEmit`: clean; eslint clean on changed files
- `vite build`: success (note: needs `NODE_OPTIONS=--max-old-space-size=8192` — default 2GB heap OOMs, pre-existing environment issue)

## Notes

- Sidebar context moved from prefix to suffix position (base → … → sidebar) so user/connection layers take precedence per Anthropic later-wins semantics.
- No migration needed: `prompt?` is optional; schema version unchanged.
