### PR TITLE
fix(mongo): honor socks5Proxy in capability client factory

### DIFF
--- a/src-tauri/src/common/mongo.rs
+++ b/src-tauri/src/common/mongo.rs
@@ -80,31 +80,22 @@ fn build_mongo_uri(config: &Value) -> Result<String, String> {
     }
 }
 
-fn parse_socks5_proxy(socks5_proxy: Option<&str>) -> Result<Option<(String, u16)>, String> {
-    let Some(proxy) = socks5_proxy.filter(|s| !s.is_empty()) else {
-        return Ok(None);
-    };
-    let (host, port_str) = proxy
-        .rsplit_once(':')
-        .ok_or_else(|| format!("Invalid socks5Proxy (no port separator): {}", proxy))?;
-    let port: u16 = port_str
-        .parse()
-        .map_err(|e| format!("Invalid socks5Proxy port '{}': {}", port_str, e))?;
-    Ok(Some((host.to_string(), port)))
+pub(crate) fn wire_socks5_proxy(client_options: &mut ClientOptions, host: &str, port: u16) {
+    client_options.socks5_proxy = Some(
+        mongodb::options::Socks5Proxy::builder()
+            .host(host)
+            .port(Some(port))
+            .build(),
+    );
+    client_options.direct_connection = Some(true);
 }
 
 fn apply_socks5_proxy_from_config(
     client_options: &mut ClientOptions,
     socks5_proxy: Option<&str>,
 ) -> Result<(), String> {
-    if let Some((host, port)) = parse_socks5_proxy(socks5_proxy)? {
-        client_options.socks5_proxy = Some(
-            mongodb::options::Socks5Proxy::builder()
-                .host(host)
-                .port(Some(port))
-                .build(),
-        );
-        client_options.direct_connection = Some(true);
+    if let Some((host, port)) = crate::common::ssh_bridge::parse_socks5_proxy(socks5_proxy)? {
+        wire_socks5_proxy(client_options, &host, port);
     }
     Ok(())
 }
@@ -239,49 +230,6 @@ mod tests {
         assert!(result.is_ok(), "URI auth should parse: {:?}", result.err());
         let (_client, db) = result.unwrap();
         assert_eq!(db, "test");
-    }
-
-    #[test]
-    fn test_parse_socks5_proxy_none() {
-        assert_eq!(parse_socks5_proxy(None).unwrap(), None);
-    }
-
-    #[test]
-    fn test_parse_socks5_proxy_empty() {
-        assert_eq!(parse_socks5_proxy(Some("")).unwrap(), None);
-    }
-
-    #[test]
-    fn test_parse_socks5_proxy_default_localhost() {
-        assert_eq!(
-            parse_socks5_proxy(Some("127.0.0.1:51234")).unwrap(),
-            Some(("127.0.0.1".to_string(), 51234))
-        );
-    }
-
-    #[test]
-    fn test_parse_socks5_proxy_custom_host() {
-        assert_eq!(
-            parse_socks5_proxy(Some("10.0.0.5:1080")).unwrap(),
-            Some(("10.0.0.5".to_string(), 1080))
-        );
-    }
-
-    #[test]
-    fn test_parse_socks5_proxy_no_colon() {
-        let err = parse_socks5_proxy(Some("invalid")).unwrap_err();
-        assert!(err.contains("no port separator"), "got: {}", err);
-    }
-
-    #[test]
-    fn test_parse_socks5_proxy_bad_port() {
-        let err = parse_socks5_proxy(Some("127.0.0.1:abc")).unwrap_err();
-        assert!(err.contains("Invalid socks5Proxy port"), "got: {}", err);
-    }
-
-    #[test]
-    fn test_parse_socks5_proxy_empty_port() {
-        assert!(parse_socks5_proxy(Some("127.0.0.1:")).is_err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/common/mongo.rs
+++ b/src-tauri/src/common/mongo.rs
@@ -80,18 +80,54 @@ fn build_mongo_uri(config: &Value) -> Result<String, String> {
     }
 }
 
+fn parse_socks5_proxy(socks5_proxy: Option<&str>) -> Result<Option<(String, u16)>, String> {
+    let Some(proxy) = socks5_proxy.filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let (host, port_str) = proxy
+        .rsplit_once(':')
+        .ok_or_else(|| format!("Invalid socks5Proxy (no port separator): {}", proxy))?;
+    let port: u16 = port_str
+        .parse()
+        .map_err(|e| format!("Invalid socks5Proxy port '{}': {}", port_str, e))?;
+    Ok(Some((host.to_string(), port)))
+}
+
+fn apply_socks5_proxy_from_config(
+    client_options: &mut ClientOptions,
+    socks5_proxy: Option<&str>,
+) -> Result<(), String> {
+    if let Some((host, port)) = parse_socks5_proxy(socks5_proxy)? {
+        client_options.socks5_proxy = Some(
+            mongodb::options::Socks5Proxy::builder()
+                .host(host)
+                .port(Some(port))
+                .build(),
+        );
+        client_options.direct_connection = Some(true);
+    }
+    Ok(())
+}
+
+async fn build_client_options(config: &Value) -> Result<ClientOptions, String> {
+    let uri = build_mongo_uri(config)?;
+    let mut client_options = ClientOptions::parse(&uri)
+        .await
+        .map_err(|e| format!("Failed to parse MongoDB connection options: {}", e))?;
+    let socks5_proxy = config.get("socks5Proxy").and_then(|v| v.as_str());
+    apply_socks5_proxy_from_config(&mut client_options, socks5_proxy)?;
+    Ok(client_options)
+}
+
 pub(crate) async fn create_mongo_client_from_config(
     config: &Value,
 ) -> Result<(MongoClient, String), String> {
-    let uri = build_mongo_uri(config)?;
     let database = config
         .get("database")
         .and_then(|v| v.as_str())
         .unwrap_or("test")
         .to_string();
-    let client_options = ClientOptions::parse(&uri)
-        .await
-        .map_err(|e| format!("Failed to parse MongoDB connection options: {}", e))?;
+    let client_options = build_client_options(config).await?;
     let client = MongoClient::with_options(client_options)
         .map_err(|e| format!("Failed to create MongoDB client: {}", e))?;
     Ok((client, database))
@@ -203,5 +239,136 @@ mod tests {
         assert!(result.is_ok(), "URI auth should parse: {:?}", result.err());
         let (_client, db) = result.unwrap();
         assert_eq!(db, "test");
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_none() {
+        assert_eq!(parse_socks5_proxy(None).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_empty() {
+        assert_eq!(parse_socks5_proxy(Some("")).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_default_localhost() {
+        assert_eq!(
+            parse_socks5_proxy(Some("127.0.0.1:51234")).unwrap(),
+            Some(("127.0.0.1".to_string(), 51234))
+        );
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_custom_host() {
+        assert_eq!(
+            parse_socks5_proxy(Some("10.0.0.5:1080")).unwrap(),
+            Some(("10.0.0.5".to_string(), 1080))
+        );
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_no_colon() {
+        let err = parse_socks5_proxy(Some("invalid")).unwrap_err();
+        assert!(err.contains("no port separator"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_bad_port() {
+        let err = parse_socks5_proxy(Some("127.0.0.1:abc")).unwrap_err();
+        assert!(err.contains("Invalid socks5Proxy port"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_empty_port() {
+        assert!(parse_socks5_proxy(Some("127.0.0.1:")).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_apply_socks5_proxy_sets_fields() {
+        let mut options = ClientOptions::parse("mongodb://localhost:27017").await.unwrap();
+        apply_socks5_proxy_from_config(&mut options, Some("127.0.0.1:51234")).unwrap();
+        let proxy = options.socks5_proxy.expect("socks5_proxy must be set");
+        assert_eq!(proxy.host, "127.0.0.1");
+        assert_eq!(proxy.port, Some(51234));
+        assert_eq!(options.direct_connection, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_apply_socks5_proxy_none_no_changes() {
+        let mut options = ClientOptions::parse("mongodb://localhost:27017").await.unwrap();
+        apply_socks5_proxy_from_config(&mut options, None).unwrap();
+        assert!(options.socks5_proxy.is_none());
+        assert!(options.direct_connection.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_apply_socks5_proxy_malformed_returns_err() {
+        let mut options = ClientOptions::parse("mongodb://localhost:27017").await.unwrap();
+        let err = apply_socks5_proxy_from_config(&mut options, Some("invalid")).unwrap_err();
+        assert!(err.contains("no port separator"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn test_build_client_options_applies_socks5_proxy() {
+        let options = build_client_options(&json!({
+            "host": "ssh-mongo-test", "port": 27017,
+            "socks5Proxy": "127.0.0.1:51234",
+        }))
+        .await
+        .expect("options should build");
+        let proxy = options.socks5_proxy.expect("socks5_proxy must be set");
+        assert_eq!(proxy.host, "127.0.0.1");
+        assert_eq!(proxy.port, Some(51234));
+        assert_eq!(options.direct_connection, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_build_client_options_no_socks5_no_proxy() {
+        let options = build_client_options(&json!({
+            "host": "127.0.0.1", "port": 27018,
+        }))
+        .await
+        .expect("options should build");
+        assert!(options.socks5_proxy.is_none());
+        assert!(options.direct_connection.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_build_client_options_uri_auth_with_socks5() {
+        let options = build_client_options(&json!({
+            "authKind": "uri",
+            "uri": "mongodb://u:p@mongo.example.com:27018/app",
+            "socks5Proxy": "127.0.0.1:51234",
+        }))
+        .await
+        .expect("options should build");
+        let proxy = options.socks5_proxy.expect("socks5_proxy must be set");
+        assert_eq!(proxy.host, "127.0.0.1");
+        assert_eq!(proxy.port, Some(51234));
+        assert_eq!(options.direct_connection, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_create_mongo_client_with_socks5_proxy() {
+        let result = create_mongo_client_from_config(&json!({
+            "host": "ssh-mongo-test", "port": 27017, "database": "testdb",
+            "socks5Proxy": "127.0.0.1:51234",
+        }))
+        .await;
+        assert!(result.is_ok(), "should build client: {:?}", result.err());
+        let (_client, db) = result.unwrap();
+        assert_eq!(db, "testdb");
+    }
+
+    #[tokio::test]
+    async fn test_create_mongo_client_socks5_malformed_returns_err() {
+        let result = create_mongo_client_from_config(&json!({
+            "host": "ssh-mongo-test", "port": 27017,
+            "socks5Proxy": "invalid",
+        }))
+        .await;
+        let err = result.unwrap_err();
+        assert!(err.contains("no port separator"), "got: {}", err);
     }
 }

--- a/src-tauri/src/common/ssh_bridge.rs
+++ b/src-tauri/src/common/ssh_bridge.rs
@@ -181,6 +181,23 @@ pub async fn resolve_ssh_in_place(app: &AppHandle, config: &mut Value) -> Result
     Ok(())
 }
 
+/// Inverse of the `socks5Proxy` injection in `resolve_ssh_in_place` —
+/// ssh_bridge owns both the injection and the parsing of this format.
+pub(crate) fn parse_socks5_proxy(
+    socks5_proxy: Option<&str>,
+) -> Result<Option<(String, u16)>, String> {
+    let Some(proxy) = socks5_proxy.filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let (host, port_str) = proxy
+        .rsplit_once(':')
+        .ok_or_else(|| format!("Invalid socks5Proxy (no port separator): {}", proxy))?;
+    let port: u16 = port_str
+        .parse()
+        .map_err(|e| format!("Invalid socks5Proxy port '{}': {}", port_str, e))?;
+    Ok(Some((host.to_string(), port)))
+}
+
 pub fn extract_remote_target(config: &Value) -> (String, u16) {
     let obj = match config.as_object() {
         Some(o) => o,
@@ -465,5 +482,48 @@ mod tests {
         let (host, port) = extract_remote_target(&config);
         assert_eq!(host, "bastion.internal");
         assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_none() {
+        assert_eq!(parse_socks5_proxy(None).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_empty() {
+        assert_eq!(parse_socks5_proxy(Some("")).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_default_localhost() {
+        assert_eq!(
+            parse_socks5_proxy(Some("127.0.0.1:51234")).unwrap(),
+            Some(("127.0.0.1".to_string(), 51234))
+        );
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_custom_host() {
+        assert_eq!(
+            parse_socks5_proxy(Some("10.0.0.5:1080")).unwrap(),
+            Some(("10.0.0.5".to_string(), 1080))
+        );
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_no_colon() {
+        let err = parse_socks5_proxy(Some("invalid")).unwrap_err();
+        assert!(err.contains("no port separator"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_bad_port() {
+        let err = parse_socks5_proxy(Some("127.0.0.1:abc")).unwrap_err();
+        assert!(err.contains("Invalid socks5Proxy port"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_parse_socks5_proxy_empty_port() {
+        assert!(parse_socks5_proxy(Some("127.0.0.1:")).is_err());
     }
 }

--- a/src-tauri/src/mongo_client.rs
+++ b/src-tauri/src/mongo_client.rs
@@ -55,15 +55,7 @@ fn tunnel_port(ssh_enabled: bool, endpoint_host: &str, endpoint_port: u16) -> Op
 /// The URI keeps the real host, so no certificate-validation skip is needed.
 fn apply_socks5_proxy(client_options: &mut ClientOptions, socks5_port: Option<u16>) {
     if let Some(port) = socks5_port {
-        client_options.socks5_proxy = Some(
-            mongodb::options::Socks5Proxy::builder()
-                .host("127.0.0.1")
-                .port(Some(port))
-                .build(),
-        );
-        // Replica-set discovery would hand back internal IPs unreachable
-        // through the tunnel; force direct connection (same as dbx).
-        client_options.direct_connection = Some(true);
+        crate::common::mongo::wire_socks5_proxy(client_options, "127.0.0.1", port);
     }
 }
 


### PR DESCRIPTION
## Problem

`create_mongo_client_from_config` (the capability-channel Mongo client factory) ignored the `socks5Proxy` field that `ssh_bridge::resolve_ssh_in_place` injects into the connection config in **SOCKS5 SSH tunnel mode** (`exposeLan: false`).

In SOCKS5 mode the config keeps the REAL remote hostname (e.g. `ssh-mongo-test`) and carries `socks5Proxy="127.0.0.1:PORT"`. Because the client factory never applied the proxy, the mongodb driver attempted a **direct DNS lookup of the remote hostname from the local machine** and failed:

```
failed to lookup address information: ssh-mongo-test
```

Port-forward mode (`exposeLan: true`) and direct connections were unaffected — the bug was specific to SOCKS5 tunnel mode on the **capability** path. The Tauri-command path (`mongo_client.rs`) already had its own `apply_socks5_proxy` and was never broken.

## Changes

### Commit 1 — `fix(mongo): honor socks5Proxy in capability client factory`

- Extract `build_client_options(config)` from `create_mongo_client_from_config`
- Add `apply_socks5_proxy_from_config(opts, socks5Proxy)` — mirrors `mongo_client.rs::apply_socks5_proxy` but accepts the capability config's `"host:port"` string (the Tauri path receives `Option<u16>` from the resolved `TunnelEndpoint`)
- Force `direct_connection = Some(true)` to skip replica-set discovery over the tunnel (would hand back internal IPs unreachable locally)
- Port-forward and direct modes are unaffected
- 15 inline tests covering parse/apply/build paths, URI-auth mode, malformed input (fail-fast), and port-forward regression

### Commit 2 — `refactor(mongo): extract shared socks5 core, centralize parser in ssh_bridge`

Eliminates the duplication introduced by Commit 1 between the two Mongo paths:

- **`ssh_bridge.rs`** — `parse_socks5_proxy` moved here so the tunnel module owns **both** the injection (`resolve_ssh_in_place` writes `socks5Proxy` into config) and the parsing of the `host:port` format. Single source of truth.
- **`common/mongo.rs`** — new `pub(crate) wire_socks5_proxy(opts, host, port)` extracts the 6-line core (`Socks5Proxy::builder` + `direct_connection`) that was duplicated in `common/mongo.rs` and `mongo_client.rs`.
- **`mongo_client.rs`** — `apply_socks5_proxy` body goes from 9 lines to 1: delegates to `wire_socks5_proxy`.
- **`common/mongo.rs`** — `apply_socks5_proxy_from_config` delegates to `ssh_bridge::parse_socks5_proxy` + `wire_socks5_proxy`.
- 7 parse tests moved to ssh_bridge test module.

### Architecture after refactor

```
ssh_bridge.rs
├── resolve_ssh_in_place()     → injects "socks5Proxy": "127.0.0.1:{port}" into config
├── parse_socks5_proxy()       → parses that string back to (host, port)
└── resolve_ssh_tunnel()       → returns TunnelEndpoint { socks5_port }

common/mongo.rs
├── wire_socks5_proxy()        ← pub(crate) shared core
└── apply_socks5_proxy_from_config()  → ssh_bridge::parse + wire_socks5_proxy

mongo_client.rs
└── apply_socks5_proxy()       → wire_socks5_proxy("127.0.0.1", port)
```

Zero behavior change from the refactor — 128 tests pass.

## Why not unify the two entry points?

The capability path (`resolve_ssh_in_place` → config `Value` with `socks5Proxy` string) and the Tauri-command path (`resolve_ssh_tunnel` → `TunnelEndpoint` with `socks5_port: u16`) serve different consumers with different input shapes. Both already delegate to the same internal `resolve_connection_target`. Fully merging them would require restructuring the capability dispatch flow — out of scope for this fix.

## Verification

- `cargo check` — exit 0
- `cargo test --lib -- ssh_bridge mongo` — **128 passed**, 0 failed
- `cargo clippy` — no new warnings in touched lines (pre-existing in unrelated DynamoDB code)
- CI: all green (macOS/ubuntu/windows builds, lint-audit, codecov, snyk)