### PR TITLE
fix(connection): persist Agent Prompt across connection edits

### DIFF
--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -845,12 +845,16 @@ export const useConnectionStore = defineStore('connectionStore', {
       try {
         const newConnection = {
           ...connection,
-          id: connection.id || this.connections.length + 1,
+          id: connection.id ?? this.connections.length + 1,
         } as Connection;
 
         if (connection.id) {
-          const index = this.connections.findIndex(c => c.id === connection.id);
-          if (index !== -1) {
+          const index = this.connections.findIndex(
+            current => String(current.id) === String(newConnection.id),
+          );
+          if (index === -1) {
+            this.connections.push(newConnection);
+          } else {
             this.connections[index] = newConnection;
           }
         } else {

--- a/src/views/connect/components/connection-prompt-dialog.vue
+++ b/src/views/connect/components/connection-prompt-dialog.vue
@@ -17,6 +17,7 @@
         <textarea
           v-model="draft"
           class="prompt-textarea"
+          autocomplete="off"
           :placeholder="$t('connection.prompt.placeholder')"
         />
       </div>

--- a/src/views/connect/components/connection-prompt-dialog.vue
+++ b/src/views/connect/components/connection-prompt-dialog.vue
@@ -17,10 +17,7 @@
         <textarea
           v-model="draft"
           class="prompt-textarea"
-          autocomplete="off"
-          autocapitalize="off"
-          autocorrect="off"
-          spellcheck="false"
+          v-bind="inputProps"
           :placeholder="$t('connection.prompt.placeholder')"
         />
       </div>
@@ -45,6 +42,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { X } from 'lucide-vue-next';
+import { inputProps } from '@/common';
 import {
   Dialog,
   DialogContent,

--- a/src/views/connect/components/connection-prompt-dialog.vue
+++ b/src/views/connect/components/connection-prompt-dialog.vue
@@ -18,6 +18,9 @@
           v-model="draft"
           class="prompt-textarea"
           autocomplete="off"
+          autocapitalize="off"
+          autocorrect="off"
+          spellcheck="false"
           :placeholder="$t('connection.prompt.placeholder')"
         />
       </div>

--- a/src/views/connect/components/dynamodb-connect-dialog.vue
+++ b/src/views/connect/components/dynamodb-connect-dialog.vue
@@ -1121,9 +1121,9 @@ const showMedal = (con: DynamoDBConnection | null) => {
   showModal.value = true;
   resetResult();
   if (con) {
-    formData.value = { ...con };
+    formData.value = { ...con, prompt: con.prompt ?? undefined };
     sshConfig.value = con.sshTunnel ? { ...con.sshTunnel } : { enabled: false };
-    veeResetForm({ values: { ...con } });
+    veeResetForm({ values: { ...con, prompt: con.prompt ?? undefined } });
     connectionMode.value = con.endpointUrl
       ? 'local'
       : con.auth?.kind === 'profile'

--- a/src/views/connect/components/dynamodb-connect-dialog.vue
+++ b/src/views/connect/components/dynamodb-connect-dialog.vue
@@ -1123,7 +1123,7 @@ const showMedal = (con: DynamoDBConnection | null) => {
   if (con) {
     formData.value = { ...con, prompt: con.prompt ?? undefined };
     sshConfig.value = con.sshTunnel ? { ...con.sshTunnel } : { enabled: false };
-    veeResetForm({ values: { ...con, prompt: con.prompt ?? undefined } });
+    veeResetForm({ values: { ...con } });
     connectionMode.value = con.endpointUrl
       ? 'local'
       : con.auth?.kind === 'profile'

--- a/src/views/connect/components/es-connect-dialog.vue
+++ b/src/views/connect/components/es-connect-dialog.vue
@@ -498,12 +498,7 @@ const showMedal = (
     authType.value = resolvedAuthType;
     sshConfig.value = con.sshTunnel ? { ...con.sshTunnel } : { enabled: false };
     veeResetForm({
-      values: {
-        ...cloneDeep(con),
-        prompt: con.prompt ?? undefined,
-        selectedIndex,
-        authType: resolvedAuthType,
-      },
+      values: { ...cloneDeep(con), selectedIndex, authType: resolvedAuthType },
     });
     modalTitle.value = lang.t('connection.edit');
   } else {

--- a/src/views/connect/components/es-connect-dialog.vue
+++ b/src/views/connect/components/es-connect-dialog.vue
@@ -489,10 +489,22 @@ const showMedal = (
   if (con) {
     const selectedIndex = con.activeIndex?.index || '';
     const resolvedAuthType = (con.authType as 'basic' | 'apiKey' | undefined) || 'basic';
-    formData.value = { ...cloneDeep(con), selectedIndex, authType: resolvedAuthType };
+    formData.value = {
+      ...cloneDeep(con),
+      prompt: con.prompt ?? undefined,
+      selectedIndex,
+      authType: resolvedAuthType,
+    };
     authType.value = resolvedAuthType;
     sshConfig.value = con.sshTunnel ? { ...con.sshTunnel } : { enabled: false };
-    veeResetForm({ values: { ...cloneDeep(con), selectedIndex, authType: resolvedAuthType } });
+    veeResetForm({
+      values: {
+        ...cloneDeep(con),
+        prompt: con.prompt ?? undefined,
+        selectedIndex,
+        authType: resolvedAuthType,
+      },
+    });
     modalTitle.value = lang.t('connection.edit');
   } else {
     const type = initialType ?? DatabaseType.ELASTICSEARCH;
@@ -587,14 +599,18 @@ const saveConnect = async (event: MouseEvent) => {
 const saveConnectConfirm = async () => {
   saveLoading.value = true;
   try {
-    await saveConnection({
+    const result = await saveConnection({
       ...formData.value,
       activeIndex: formData.value.selectedIndex
         ? { index: formData.value.selectedIndex }
         : undefined,
       sshTunnel: { ...sshConfig.value },
     } as Connection);
-    closeModal();
+    if (result.success) {
+      closeModal();
+    } else {
+      fail(result.message);
+    }
   } catch (e) {
     const error = e as CustomError;
     fail(error.details || `Connection failed (status: ${error.status})`);

--- a/src/views/connect/components/mongodb-connect-dialog.vue
+++ b/src/views/connect/components/mongodb-connect-dialog.vue
@@ -627,7 +627,7 @@ const showMedal = (con: MongoDBConnection | null) => {
   resetResult();
 
   if (con) {
-    formData.value = cloneDeep(con);
+    formData.value = { ...cloneDeep(con), prompt: con.prompt ?? undefined };
     tlsChecked.value = con.tls ?? false;
     sshConfig.value = con.sshTunnel ? { ...con.sshTunnel } : { enabled: false };
 

--- a/tests/connectionStore.test.ts
+++ b/tests/connectionStore.test.ts
@@ -998,6 +998,48 @@ describe('connectionStore actions', () => {
       expect((store.connections[0] as ElasticsearchConnection).host).toBe('http://updated');
     });
 
+    it('persists a prompt when updating an existing connection', async () => {
+      await store.saveConnection(esConnection);
+
+      const result = await store.saveConnection({
+        ...esConnection,
+        id: 1,
+        prompt: 'Orders cluster context',
+      });
+
+      expect(result.success).toBe(true);
+      expect(store.connections[0].prompt).toBe('Orders cluster context');
+    });
+
+    it('matches numeric and string connection ids when updating', async () => {
+      await store.saveConnection({ ...esConnection, id: 9, name: 'aws-es-cluster' });
+
+      const result = await store.saveConnection({
+        ...esConnection,
+        id: '9',
+        name: 'aws-es-cluster',
+        prompt: 'AWS cluster context',
+      });
+
+      expect(result.success).toBe(true);
+      expect(store.connections).toHaveLength(1);
+      expect(store.connections[0].id).toBe('9');
+      expect(store.connections[0].prompt).toBe('AWS cluster context');
+    });
+
+    it('upserts a record when an existing id cannot be found', async () => {
+      const result = await store.saveConnection({
+        ...esConnection,
+        id: 9,
+        name: 'aws-es-cluster',
+        prompt: 'AWS cluster context',
+      });
+
+      expect(result.success).toBe(true);
+      expect(store.connections).toHaveLength(1);
+      expect(store.connections[0].prompt).toBe('AWS cluster context');
+    });
+
     it('returns success false when storeApi.set throws', async () => {
       jest.spyOn(storeApi, 'set').mockRejectedValueOnce(new Error('Storage full'));
       const result = await store.saveConnection(esConnection);


### PR DESCRIPTION
## Summary
- normalize connection IDs and upsert records so edits cannot be silently dropped
- preserve connection-level Agent Prompt during Elasticsearch, MongoDB, and DynamoDB dialog hydration
- keep the ES dialog open and show the persistence error when saving fails
- disable browser autocomplete for the Agent Prompt textarea
- add regression coverage for prompt persistence, numeric/string IDs, and missing-record upsert behavior

Closes #488